### PR TITLE
feat: add liveness endpoint for k8s

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && export $(grep -v '^\\s*$\\|^\\s*\\#' .env.runtime) && printenv | grep API && astro build",
+    "build": "astro check && export $(grep -v '^\\s*$\\|^\\s*\\#' .env.runtime) && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/src/pages/liveness.ts
+++ b/src/pages/liveness.ts
@@ -1,0 +1,24 @@
+export const prerender = false;
+
+/**
+ * GET Request with JSON response
+ * @returns {Response}
+ */
+export async function GET() {
+  return new Response(JSON.stringify({ alive: true }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+/**
+ * HEAD Request
+ * @returns {Response}
+ */
+export function HEAD() {
+  return new Response(null, {
+    status: 204,
+  });
+}


### PR DESCRIPTION
Have a dedicated endpoint for liveness checks. 

(Also removed a debug output from build)