### PR TITLE
fix: split tg25 date and location on new line

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,7 +18,8 @@
       class="aspect-thumbnail object-cover"
     />
   </a>
-  <span class="text-l text-white"
-    >🗓16.-20. april 2025 - 🌍Vikingskipet, Hamar</span
-  >
+  <span class="text-l text-white flex flex-col">
+    <span>🗓 16.-20. april 2025</span>
+    <span>🌍 Vikingskipet, Hamar</span>
+  </span>
 </header>


### PR DESCRIPTION
Before on small screens:
<img width="384" alt="bilde" src="https://github.com/user-attachments/assets/e54ebf6a-6e9e-4a4e-a9c0-7a51c1541fd4">

After:
<img width="379" alt="bilde" src="https://github.com/user-attachments/assets/ccc856b6-4191-4ec2-b363-9893268d37d2">

Large screen:
<img width="1314" alt="bilde" src="https://github.com/user-attachments/assets/51da315a-449f-428a-840c-f8ea974dbb27">
