### PR TITLE
feat: show article intro

### DIFF
--- a/src/components/Intro.astro
+++ b/src/components/Intro.astro
@@ -1,0 +1,16 @@
+---
+type Props = {
+  text: string;
+  color?: string;
+};
+const { text, color = "text-white" } = Astro.props;
+---
+
+<p
+  class=`text-base/7 ${color} font-bold mb-5`
+  style={{
+    maxWidth: "65ch", // m-w-prose didn't work for some reason
+  }}
+>
+  {text}
+</p>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import H1 from "../../components/H1.astro";
+import Intro from "../../components/Intro.astro";
 import Main from "../../components/Main.astro";
 import ContentContainer from "../../components/ContentContainer.astro";
 import Layout from "../../layouts/Layout.astro";
@@ -88,6 +89,7 @@ const article = await fetchArticleById({
     </ContentContainer>
     <ContentContainer>
       <!-- Article Content -->
+      <Intro text={article.intro} />
       <div class="prose" set:html={article.body} />
     </ContentContainer>
   </Main>


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/33

Makes sure intro text as stored in CMS is shown.

I'm still leaning towards removing this field entirely before site gets too many articles, as we see to be repeating ourselves quite a lot in intro and start of contents. Wagtail has built in promotion title and description fields that could be used as a way to adjust seo and sharing data when required.

## Examples of repetition (first bold paragraph is intro, rest is body)

<img width="761" alt="Screenshot 2024-10-11 at 21 21 07" src="https://github.com/user-attachments/assets/ecf18b16-4cbe-4ba0-9edb-e2b7b9d5c0e2">

---

<img width="736" alt="Screenshot 2024-10-11 at 21 20 58" src="https://github.com/user-attachments/assets/e0ea1659-491a-4351-b84a-5428e6910aa0">

---

<img width="763" alt="Screenshot 2024-10-11 at 21 20 48" src="https://github.com/user-attachments/assets/f3258459-f18f-4d54-a748-1c92f7c689d3">

---

<img width="771" alt="Screenshot 2024-10-11 at 21 20 32" src="https://github.com/user-attachments/assets/95b20f6e-e6f7-4eef-9b4f-7afb5bec120c">
