### PR TITLE
fix: remove check from build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && export $(grep -v '^\\s*$\\|^\\s*\\#' .env.runtime) && astro build",
+    "build": "export $(grep -v '^\\s*$\\|^\\s*\\#' .env.runtime) && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "prepare": "husky"


### PR DESCRIPTION
As seen in https://github.com/gathering/tgno-frontend/actions/runs/11372989358/job/31638566785?pr=62 CI `build-test` fails if `astro check` relies on a dev dependency. This happens since our build command also runs `astro check`, and in `build-test` this happens in a production context where no dev dependencies are available.

Even with check removed I assume `astro build` will fail if an error is encountered, and we have separate `checks` job that runs `astro checks` (in dev context) to block PR in case of errors.