### PR TITLE
fix: prettier ignore for pnpm-lock.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml


### PR DESCRIPTION
pnpm-lock.yaml is a auto-generated file, no need to apply prettier on it.
See #61 