### PR TITLE
feat: move news section up on frontpage

### DIFF
--- a/src/components/sections/AboutComp.astro
+++ b/src/components/sections/AboutComp.astro
@@ -3,7 +3,7 @@
 ---
 
 <section
-  class="text-white p-8 rounded-3xl border-solid border-4 border-backgroundSecondary my-2"
+  class="text-white p-8 rounded-3xl border-solid border-4 border-backgroundSecondary content-center"
 >
   <div class="container mx-auto prose">
     <h1 class="text-3xl font-bold text-center mb-6">Hva er The Gathering?</h1>

--- a/src/components/sections/CrewDescriptionComp.astro
+++ b/src/components/sections/CrewDescriptionComp.astro
@@ -8,13 +8,13 @@ interface Props {
 const { image } = Astro.props;
 ---
 
-<section class="relative h-[500px]">
+<section class="relative h-[300px] sm:h-[500px]">
   <img
     src={image}
     alt="Crew beskrivelse bilde"
     class="w-full h-full object-cover rounded-3xl"
   />
-  <div class="absolute inset-0 flex justify-center items-center">
+  <div class="absolute inset-0 flex justify-center items-center sm:p-4">
     <Box
       itemCenter={true}
       title="Hvem styrer scenelysene?"

--- a/src/components/sections/CrewJoinComp.astro
+++ b/src/components/sections/CrewJoinComp.astro
@@ -8,13 +8,15 @@ interface Props {
 const { image } = Astro.props;
 ---
 
-<section class="relative h-[500px]">
+<section class="relative h-[300px] sm:h-[500px]">
   <img
     src={image}
     alt="Crew beskrivelse bilde"
     class="w-full h-full object-cover rounded-3xl"
   />
-  <div class="absolute inset-0 flex justify-center items-start sm:items-center">
+  <div
+    class="absolute inset-0 flex justify-center items-start sm:items-center sm:p-4"
+  >
     <Box
       itemCenter={true}
       title="Vi søker frivillige!"

--- a/src/components/sections/TechBlogComp.astro
+++ b/src/components/sections/TechBlogComp.astro
@@ -8,7 +8,7 @@ interface Props {
 const { image } = Astro.props;
 ---
 
-<section class="relative h-[500px]">
+<section class="relative h-[350px] sm:h-[500px]">
   <img
     src={image}
     alt="Tech blogg bilde"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,10 +14,22 @@ import TechBlogComp from "../components/sections/TechBlogComp.astro";
     <div class="max-w-4xl">
       <H1 text="BLI MED I NORGES STØRSTE PÅSKEHYTTE" />
     </div>
-    <CrewJoinComp image="/images/tg23-oversikt.jpg" />
-    <AboutComp />
-    <CrewDescriptionComp image="/images/tg19-lights.jpg" />
-    <NewsComp />
-    <TechBlogComp image="/images/tg23-crew.jpg" />
+    <div class="grid sm:grid-cols-5 gap-4 w-full">
+      <div class="sm:col-span-2">
+        <CrewJoinComp image="/images/tg23-oversikt.jpg" />
+      </div>
+      <div class="sm:col-span-3 sm:order-first flex">
+        <AboutComp />
+      </div>
+      <div class="sm:col-span-5">
+        <NewsComp />
+      </div>
+      <div class="sm:col-span-2">
+        <CrewDescriptionComp image="/images/tg19-lights.jpg" />
+      </div>
+      <div class="sm:col-span-3">
+        <TechBlogComp image="/images/tg23-crew.jpg" />
+      </div>
+    </div>
   </Main>
 </Layout>


### PR DESCRIPTION
A few tweaks here and there to make news appear earlier on frontpage. Main trick is using grid to allow more items next to each other on desktop, and then slightly reorder items on mobile and reduce CTA heights.