### PR TITLE
feat(add): Add simple PR preview environments

### DIFF
--- a/.env.runtime
+++ b/.env.runtime
@@ -1,5 +1,6 @@
 # https://docs.astro.build/en/guides/integrations-guide/node/#runtime-environment-variables
 # Variables that should be loaded on runtime and not during build is added here, the value is not used for anything
 API_URL=placeholder
+SITE_URL=placeholder
 MATOMO_SITE_ID=placeholder
 MATOMO_INSTANCE_URL=placeholder

--- a/.github/workflows/cleanup-preview.yaml
+++ b/.github/workflows/cleanup-preview.yaml
@@ -1,0 +1,54 @@
+name: Cleanup Preview Environment
+
+on:
+  pull_request:
+    types:
+      - closed
+      - converted_to_draft
+
+env:
+  ARGOCD_APP_NAME: tgno-preview-pr${{ github.event.number }}
+  TAG: preview-pr${{ github.event.number }}
+
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup-preview-environment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to ArgoCD
+        uses: clowdhaus/argo-cd-action@v2.2.0
+        with:
+          command: login
+          options: >-
+            ${{ secrets.ARGOCD_URL }}
+            --username ${{ secrets.ARGOCD_USERNAME }}
+            --password ${{ secrets.ARGOCD_PASSWORD }}
+            --grpc-web
+            --skip-test-tls
+      - name: Delete ArgoCD Application
+        uses: clowdhaus/argo-cd-action@v2.2.0
+        with:
+          command: app delete
+          options: >-
+            ${{ env.ARGOCD_APP_NAME }}
+            --cascade
+            --yes
+            --grpc-web
+        continue-on-error: true
+      - name: Remove Docker Tag
+        uses: rafalkk/remove-dockertag-action@v1
+        with:
+          tag_name: preview-pr${{ github.event.number }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+      - name: Allow failures
+        run: true
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: setup-preview-environment
+          message: |
+            ### Preview Environment deleted

--- a/.github/workflows/setup-preview.yaml
+++ b/.github/workflows/setup-preview.yaml
@@ -1,0 +1,82 @@
+name: Build and deploy Preview Environment
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+env:
+  TAG: preview-pr${{ github.event.number }}
+  ARGOCD_APP_NAME: tgno-preview-pr${{ github.event.number }}
+  KUSTOMIZE_REPO: https://github.com/gathering/k8s-iac.git
+  KUSTOMIZE_PATH: tgno/preview-frontend
+  DOMAIN: tgno-pr${{ github.event.number }}.preview.tg.no
+
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  # Build docker image and push it to registry
+  build:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.docker_build_push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build astro image for amd64
+        id: docker_build_push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            APP_ENV=development
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  setup-preview-environment:
+    needs: build
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install requests
+      - run: >
+          python tools/create-preview.py
+          --argocd-url ${{ secrets.ARGOCD_URL }}
+          --argocd-user ${{ secrets.ARGOCD_USERNAME }}
+          --argocd-password ${{ secrets.ARGOCD_PASSWORD }}
+          --name ${{ env.ARGOCD_APP_NAME }}
+          --host ${{ env.DOMAIN }}
+          --kustomize-path ${{ env.KUSTOMIZE_PATH }}
+          --image ghcr.io/${{ github.repository }}@${{needs.build.outputs.digest}}
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: setup-preview-environment
+          message: |
+            ### Preview Environment created
+            ${{ github.sha }} live at https://${{ env.DOMAIN }}
+
+            ghcr.io/${{ github.repository }}:${{ env.TAG }} (${{needs.build.outputs.digest}})
+            [ArgoCD Application](https://${{ secrets.ARGOCD_URL }}/applications/${{ env.ARGOCD_APP_NAME }})

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /api/
-Disallow: /admin/
-Disallow: /django-admin/

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly API_URL: string;
+  readonly SITE_URL: string;
   readonly MATOMO_SITE_ID: string;
   readonly MATOMO_INSTANCE_URL: string;
 }

--- a/src/pages/liveness.ts
+++ b/src/pages/liveness.ts
@@ -2,7 +2,6 @@ export const prerender = false;
 
 /**
  * GET Request with JSON response
- * @returns {Response}
  */
 export async function GET() {
   return new Response(JSON.stringify({ alive: true }), {
@@ -14,8 +13,7 @@ export async function GET() {
 }
 
 /**
- * HEAD Request
- * @returns {Response}
+ * HEAD Request. Just return 204
  */
 export function HEAD() {
   return new Response(null, {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,25 @@
+export const prerender = false;
+
+import.meta.env.SITE_URL;
+
+var prod_robots = `User-agent: *
+Disallow: /api/
+Disallow: /admin/
+Disallow: /django-admin/`;
+
+var dev_robots = `User-agent: *
+Disallow: /`;
+
+/**
+ * GET Request
+ */
+export async function GET() {
+  if (import.meta.env.SITE_URL == "https://www.tg.no/") {
+    return new Response(prod_robots, {
+      status: 200,
+    });
+  }
+  return new Response(dev_robots, {
+    status: 200,
+  });
+}

--- a/tools/create-preview.py
+++ b/tools/create-preview.py
@@ -1,0 +1,78 @@
+import requests
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--argocd-url", required=True)
+parser.add_argument("--argocd-user", required=True)
+parser.add_argument("--argocd-password", required=True)
+
+parser.add_argument("--argocd-project", default="tg-systems")
+parser.add_argument("--repo", default="https://github.com/gathering/k8s-iac.git")
+parser.add_argument("--repo-revision", default="main") # branch
+parser.add_argument("--kustomize-path", required=True)
+
+parser.add_argument("--name", required=True)
+parser.add_argument("--image", required=True, type=str, nargs='+', action='extend')
+parser.add_argument("--host", required=True)
+
+args = parser.parse_args()
+
+# Login
+session_r = requests.post(f"https://{args.argocd_url}/api/v1/session", json={"username": args.argocd_user, "password": args.argocd_password})
+if session_r.status_code != 200:
+    print(session_r.text)
+    raise SystemExit("Got error on login")
+
+token = session_r.json()["token"]
+headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+# Create application object
+application = {
+  "metadata": {
+    "name": args.name
+  },
+  "spec": {
+    "destination": {
+      "namespace": args.name,
+      "server": "https://kubernetes.default.svc"
+    },
+    "project": args.argocd_project,
+    "source": {
+      "path": args.kustomize_path,
+      "kustomize": {
+        "namespace": args.name,
+        "images": args.image,
+        "patches": [{
+            "patch": f"- op: replace\n  path: /spec/rules/0/host\n  value: {args.host}",
+            "target": {
+                "kind": "Ingress",
+                "name": "tgno"
+                }
+            }],
+      },
+      "repoURL": args.repo,
+      "targetRevision": args.repo_revision
+    },
+    "syncPolicy": {
+        "syncOptions": [
+            "CreateNamespace=true",
+            "ServerSideApply=true",
+            "PruneLast=true"
+        ]
+    }
+  }
+}
+
+# Create (or update) application
+create_r = requests.post(f"https://{args.argocd_url}/api/v1/applications?upsert=true", headers=headers, json=application)
+if create_r.status_code != 200:
+    print(create_r.text)
+    raise SystemExit("Got error on create application")
+
+# Sync application
+sync_r = requests.post(f"https://{args.argocd_url}/api/v1/applications/{args.name}/sync", headers=headers)
+if sync_r.status_code != 200:
+    print(sync_r.text)
+    raise SystemExit("Got error on sync application")
+
+print("Application created/updated and synced")


### PR DESCRIPTION
Simple preview environments on all PRs. Can be used to test and showcase new features before merging to production.
The environment will be deleted after the PR is merged.

Using dev.tg.no as backend for now. If we do the same for backend we need to find a way to connect the two environments.
Had to write a little python since the argocd cli do not support setting Kustomize patches on applications. 

Part of #71