### PR TITLE
feat: add desktop sub navigation support

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,3 +1,7 @@
+---
+import NavItem from "./navigation/NavItem.astro";
+---
+
 <script>
   const mobileMenu = document.querySelector("#mobile-menu");
   const mobileMenuButton = document.querySelector(
@@ -44,19 +48,7 @@
           />
         </a>
         <ul class="hidden sm:flex w-full space-x-6 space-y-0 justify-end">
-          <li>
-            <a
-              href="/competitions/creative"
-              class="block text-white hover:text-orange-500"
-              >Kreative konkurranser</a
-            >
-          </li>
-          <li>
-            <a
-              href="/competitions/esport"
-              class="block text-white hover:text-orange-500">E-sport</a
-            >
-          </li>
+          <NavItem title="Konkurranser" />
           <li>
             <a href="/contact" class="block text-white hover:text-orange-500"
               >Kontakt oss</a

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -48,7 +48,13 @@ import NavItem from "./navigation/NavItem.astro";
           />
         </a>
         <ul class="hidden sm:flex w-full space-x-6 space-y-0 justify-end">
-          <NavItem title="Konkurranser" />
+          <NavItem
+            title="Konkurranser"
+            subItems={[
+              { title: "Kreative", path: "/competitions/creative" },
+              { title: "E-sport", path: "/competitions/esport" },
+            ]}
+          />
           <li>
             <a href="/contact" class="block text-white hover:text-orange-500"
               >Kontakt oss</a

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -52,19 +52,26 @@ import NavItem from "./navigation/NavItem.astro";
             title="Konkurranser"
             subItems={[
               { title: "Kreative", path: "/competitions/creative" },
-              { title: "E-sport", path: "/competitions/esport" },
+              { title: "Esport", path: "/competitions/esport" },
             ]}
           />
-          <li>
-            <a href="/contact" class="block text-white hover:text-orange-500"
-              >Kontakt oss</a
-            >
-          </li>
-          <li>
-            <a href="/tickets" class="block text-white hover:text-orange-500"
-              >Billetter</a
-            >
-          </li>
+          <NavItem title="Kontakt oss" path="/contact" />
+          <NavItem
+            title="Billetter"
+            path="/tickets"
+            subAlignment="right"
+            subItems={[
+              { title: "Vilkår", path: "/tickets/terms-and-conditions" },
+              {
+                title: "Arrangementsregler",
+                path: "/event/rules",
+              },
+              {
+                title: "Konstruksjonsregler",
+                path: "/event/construction-rules",
+              },
+            ]}
+          />
         </ul>
 
         <div class="absolute inset-y-0 right-0 flex items-center sm:hidden">

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -2,15 +2,17 @@
 export interface Props {
   title: string;
   path?: string;
+  subAlignment?: "left" | "right";
   subItems?: Array<{
     title: string;
     path: string;
   }>;
 }
 
-const { title, path, subItems = [] } = Astro.props;
+const { title, path, subItems = [], subAlignment = "left" } = Astro.props;
 const clickable = !!path;
 const expandable = !!subItems.length;
+
 const TextContainer = clickable ? "a" : "span";
 ---
 
@@ -47,7 +49,7 @@ const TextContainer = clickable ? "a" : "span";
   {
     expandable ? (
       <ul
-        class="hidden absolute top-0 left-0 min-w-full flex flex-col bg-backgroundSecondary space-y-1 px-2 pb-3 pt-10 rounded-b-md group-hover:flex z-0"
+        class={`hidden absolute top-0 ${subAlignment}-0 min-w-full flex flex-col bg-backgroundSecondary space-y-1 px-2 pb-3 pt-10 rounded-b-md group-hover:flex z-0`}
         id="comp-sub-nav"
         aria-role="menu"
       >

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -1,0 +1,67 @@
+---
+export interface Props {
+  title: string;
+  path?: string;
+  subItems?: Array<{
+    title: string;
+    path: string;
+  }>;
+}
+
+const { title, path, subItems = [] } = Astro.props;
+const clickable = !!path;
+const expandable = !!subItems.length;
+const TextContainer = clickable ? "a" : "span";
+---
+
+<li class="relative group bg-backgroundSecondary">
+  <TextContainer
+    href={path}
+    class={`block text-white ${clickable ? "group-hover:text-orange-500" : "group-hover:text-gray-500"} flex z-10 relative ${clickable ? "cursor-pointer" : "cursor-default"}`}
+  >
+    {title}
+    {
+      expandable ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="block h-3 w-3 m-1.5 group-hover:scale-y-[-1] transition-transform duration-100 ease-out"
+          aria-hidden="false"
+          aria-haspopup="menu"
+        >
+          <>
+            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+            <path d="M6 9l6 6l6 -6" />
+          </>
+        </svg>
+      ) : null
+    }
+  </TextContainer>
+  {
+    expandable ? (
+      <ul
+        class="hidden absolute top-0 left-0 min-w-full flex flex-col bg-backgroundSecondary space-y-1 px-2 pb-3 pt-10 rounded-b-md group-hover:flex z-0"
+        id="comp-sub-nav"
+        aria-role="menu"
+      >
+        {subItems.map((subItem) => (
+          <li>
+            <a
+              href={subItem.path}
+              class="block rounded-md px-2 py-1 text-sm font-medium text-gray-300 hover:bg-orange-500 hover:text-white"
+            >
+              {subItem.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    ) : null
+  }
+</li>

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -14,12 +14,15 @@ const clickable = !!path;
 const expandable = !!subItems.length;
 
 const TextContainer = clickable ? "a" : "span";
+const isActive =
+  path === Astro.url.pathname ||
+  subItems.some((item) => item.path === Astro.url.pathname);
 ---
 
 <li class="relative group bg-backgroundSecondary">
   <TextContainer
     href={path}
-    class={`block text-white ${clickable ? "group-hover:text-orange-500" : "group-hover:text-gray-500"} flex z-10 relative ${clickable ? "cursor-pointer" : "cursor-default"}`}
+    class={`block ${isActive ? "text-orange-500" : "text-white"} ${clickable ? "group-hover:text-orange-500" : "group-hover:text-gray-500"} flex z-10 relative ${clickable ? "cursor-pointer" : "cursor-default"}`}
   >
     {title}
     {
@@ -57,7 +60,7 @@ const TextContainer = clickable ? "a" : "span";
           <li>
             <a
               href={subItem.path}
-              class="block rounded-md px-2 py-1 text-sm font-medium text-gray-300 hover:bg-orange-500 hover:text-white"
+              class={`block rounded-md px-2 py-1 text-sm font-medium ${subItem.path === Astro.url.pathname ? "text-orange-500" : "text-gray-300"} hover:bg-orange-500 hover:text-white`}
             >
               {subItem.title}
             </a>


### PR DESCRIPTION
Desktop part of https://github.com/gathering/tgno-frontend/issues/95

Should be enough to unblock any issues that either requires multiple levels of navigation or child-items without a top level page (we see some cases of this in current project due to content production delays). On mobile we still have a bit of room to go on before we are filled up

Introduces NavItem that essentially have four possible states (when being hovered). When not hovered it gets highlighted as active if itself or any child item matches current path (exactly)

Non-clickable top item, with children
<img width="245" alt="Screenshot 2024-11-12 at 21 47 26" src="https://github.com/user-attachments/assets/4116b838-5800-480f-89f7-ebbd6c77e0b3">

Non-clickable top item, no children (🤔)
<img width="237" alt="Screenshot 2024-11-12 at 21 47 36" src="https://github.com/user-attachments/assets/bd09ee68-3876-4eeb-9971-f0373d29e0b1">

Clickable top item, with children
<img width="197" alt="Screenshot 2024-11-12 at 21 47 50" src="https://github.com/user-attachments/assets/d2f1c1f5-b511-4877-84c5-943fc21b33d3">

Clickable top item, no children
<img width="176" alt="Screenshot 2024-11-12 at 21 48 00" src="https://github.com/user-attachments/assets/043b2a05-cbbb-4acf-8736-0a1c445838d2">
