### PR TITLE
fix: avoid breaking date and location header on mobile

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -152,8 +152,10 @@ import NavItem from "./navigation/NavItem.astro";
     <span
       class="flex w-full text-white justify-end py-2 px-5 max-w-7xl justify-self-center mx-auto gap-x-3 xl:px-0"
     >
-      <span>🗓 16.-20. april 2025</span>
-      <span>🌍 Vikingskipet, Hamar</span>
+      <span>🗓 16.-20. april<span class="max-sm:hidden"> 2025</span></span>
+      <a href="https://maps.app.goo.gl/RN5QTjwpLDaWiswh8" target="_blank"
+        >🌍 Vikingskipet<span class="max-sm:hidden">, Hamar</span></a
+      >
     </span>
   </aside>
 </header>


### PR DESCRIPTION
Nothing controversial, just making it work better on the smaller mobile screen sizes