### PR TITLE
fix: frontpage box scaling on safari

### DIFF
--- a/src/components/frontpage/InfoBox.astro
+++ b/src/components/frontpage/InfoBox.astro
@@ -10,9 +10,13 @@ const { image } = Astro.props;
   class="bg-white p-4 rounded-3xl grid md:p-6 md:grid-cols-2 gap-4 md:h-full md:m-auto md:rounded-2xl"
 >
   <aside
-    class="rounded-2xl overflow-hidden h-full w-full md:rounded-xl md:order-last"
+    class="rounded-2xl overflow-hidden md:relative h-full w-full md:rounded-xl md:order-last"
   >
-    <img src={image} alt="" class="object-cover h-full" />
+    <img
+      src={image}
+      alt=""
+      class="object-cover md:h-full md:absolute md:top-0 md:right-0"
+    />
   </aside>
   <div class="flex flex-col justify-end items-start">
     <slot />


### PR DESCRIPTION
As reported on slack, this should avoid case of endlessly-high-frontpage-images in Safari desktop browsers