### PR TITLE
feat: add combined hamburger and hover navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -61,7 +61,7 @@ const NAVIGATION: NavItem[] = [
     class="flex justify-between items-center py-1 px-5 max-w-7xl mb-8 justify-self-center w-full mx-auto bg-backgroundSecondary sm:rounded-xl sm:mx-5 sm:mt-2 sm:mb-8 sm:w-auto xl:mx-auto xl:w-full"
   >
     <nav class="w-full">
-      <div class="relative h-16 flex items-center">
+      <div class="relative h-16 flex items-center justify-between">
         <a href="/" class="sm:flex gap-x-4 items-center hidden">
           <img
             src="/images/tglogo-bw.png"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -81,7 +81,7 @@ const NAVIGATION: NavItem[] = [
 
         <HeaderNavigation
           navigationItems={NAVIGATION}
-          class="flex w-full space-x-6 space-y-0 justify-end"
+          class="hidden sm:flex w-full space-x-6 space-y-0 justify-end"
           prioritized
         />
         <div class="flex items-center">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,34 @@
 ---
-import NavItem from "./navigation/NavItem.astro";
+import type { NavItem } from "../types";
+import HeaderNavigation from "./HeaderNavigation.astro";
+
+const NAVIGATION: NavItem[] = [
+  {
+    title: "Om TG",
+    path: "/about",
+    items: [
+      { title: "Bli utstiller", path: "/about/expo" },
+      { title: "Bli sponsor", path: "/about/sponsor" },
+    ],
+  },
+  {
+    title: "Konkurranser",
+    items: [
+      { title: "Kreative", path: "/competitions/creative" },
+      { title: "Esport", path: "/competitions/esport" },
+    ],
+  },
+  { title: "Kontakt oss", path: "/contact" },
+  {
+    title: "Billetter",
+    path: "/tickets",
+    items: [
+      { title: "Vilkår", path: "/tickets/terms-and-conditions" },
+      { title: "Arrangementsregler", path: "/event/rules" },
+      { title: "Konstruksjonsregler", path: "/event/construction-rules" },
+    ],
+  },
+];
 ---
 
 <script>
@@ -49,42 +78,14 @@ import NavItem from "./navigation/NavItem.astro";
             class="aspect-thumbnail object-cover"
           />
         </a>
-        <ul class="hidden sm:flex w-full space-x-6 space-y-0 justify-end">
-          <NavItem
-            title="Om TG"
-            path="/about"
-            subItems={[
-              { title: "Bli utstiller", path: "/about/expo" },
-              { title: "Bli sponsor", path: "/about/sponsor" },
-            ]}
-          />
-          <NavItem
-            title="Konkurranser"
-            subItems={[
-              { title: "Kreative", path: "/competitions/creative" },
-              { title: "Esport", path: "/competitions/esport" },
-            ]}
-          />
-          <NavItem title="Kontakt oss" path="/contact" />
-          <NavItem
-            title="Billetter"
-            path="/tickets"
-            subAlignment="right"
-            subItems={[
-              { title: "Vilkår", path: "/tickets/terms-and-conditions" },
-              {
-                title: "Arrangementsregler",
-                path: "/event/rules",
-              },
-              {
-                title: "Konstruksjonsregler",
-                path: "/event/construction-rules",
-              },
-            ]}
-          />
-        </ul>
 
-        <div class="absolute inset-y-0 right-0 flex items-center sm:hidden">
+        <HeaderNavigation
+          navigationItems={NAVIGATION}
+          class="flex w-full space-x-6 space-y-0 justify-end"
+          mode="hover"
+          prioritized
+        />
+        <div class="flex items-center">
           <button
             type="button"
             data-part="mobile-menu-trigger"
@@ -126,41 +127,12 @@ import NavItem from "./navigation/NavItem.astro";
         </div>
       </div>
       <!-- Mobile menu, show/hide based on menu state. -->
-      <div class="hidden md:hidden" id="mobile-menu" data-part="mobile-menu">
-        <ul class="space-y-3 px-2 pb-3 pt-2 flex flex-col">
-          <NavItem
-            title="Om TG"
-            path="/about"
-            subItems={[
-              { title: "Bli utstiller", path: "/about/expo" },
-              { title: "Bli sponsor", path: "/about/sponsor" },
-            ]}
-          />
-          <NavItem
-            title="Konkurranser"
-            subItems={[
-              { title: "Kreative", path: "/competitions/creative" },
-              { title: "Esport", path: "/competitions/esport" },
-            ]}
-          />
-          <NavItem title="Kontakt oss" path="/contact" />
-          <NavItem
-            title="Billetter"
-            path="/tickets"
-            subAlignment="right"
-            subItems={[
-              { title: "Vilkår", path: "/tickets/terms-and-conditions" },
-              {
-                title: "Arrangementsregler",
-                path: "/event/rules",
-              },
-              {
-                title: "Konstruksjonsregler",
-                path: "/event/construction-rules",
-              },
-            ]}
-          />
-        </ul>
+      <div class="hidden" id="mobile-menu" data-part="mobile-menu">
+        <HeaderNavigation
+          navigationItems={NAVIGATION}
+          class="space-y-3 px-2 pb-3 pt-2 flex flex-col"
+          mode="click"
+        />
       </div>
     </nav>
   </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -82,7 +82,6 @@ const NAVIGATION: NavItem[] = [
         <HeaderNavigation
           navigationItems={NAVIGATION}
           class="flex w-full space-x-6 space-y-0 justify-end"
-          mode="hover"
           prioritized
         />
         <div class="flex items-center">
@@ -131,7 +130,7 @@ const NAVIGATION: NavItem[] = [
         <HeaderNavigation
           navigationItems={NAVIGATION}
           class="space-y-3 px-2 pb-3 pt-2 flex flex-col"
-          mode="click"
+          hamburger
         />
       </div>
     </nav>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,14 +12,6 @@ const NAVIGATION: NavItem[] = [
     ],
   },
   {
-    title: "Konkurranser",
-    items: [
-      { title: "Kreative", path: "/competitions/creative" },
-      { title: "Esport", path: "/competitions/esport" },
-    ],
-  },
-  { title: "Kontakt oss", path: "/contact" },
-  {
     title: "Billetter",
     path: "/tickets",
     items: [
@@ -28,6 +20,14 @@ const NAVIGATION: NavItem[] = [
       { title: "Konstruksjonsregler", path: "/event/construction-rules" },
     ],
   },
+  {
+    title: "Konkurranser",
+    items: [
+      { title: "Kreative", path: "/competitions/creative" },
+      { title: "Esport", path: "/competitions/esport" },
+    ],
+  },
+  { title: "Kontakt oss", path: "/contact" },
 ];
 ---
 

--- a/src/components/HeaderNavigation.astro
+++ b/src/components/HeaderNavigation.astro
@@ -1,0 +1,88 @@
+---
+import type { NavItem } from "../types";
+import NavItemComponent from "./navigation/NavItem.astro";
+
+interface Props {
+  navigationItems: NavItem[];
+  mode: "click" | "hover";
+  prioritized?: boolean;
+  class?: string;
+}
+
+const {
+  navigationItems,
+  class: classNames = "",
+  mode,
+  prioritized = false,
+} = Astro.props;
+
+const lastItemIndex = navigationItems.length - 1;
+---
+
+<script>
+  const prioritizedMenus = Array.from(
+    document.querySelectorAll('ul[data-prioritized="true"]'),
+  );
+
+  function updateVisibilityFactory(menu: Element | null) {
+    const items = Array.from(
+      menu?.querySelectorAll('[data-component="nav-item"]') || [],
+    );
+
+    if (!menu || !items) {
+      return;
+    }
+
+    // Store actual required width for each item, doing this initially
+    // avoids need for overflow style on container
+    // Adjust initial value to add preferred extra margin
+    let usedWidth = 0;
+    items.forEach((item) => {
+      // Adjust value to account for margin on each item
+      const margin = 24;
+      usedWidth += margin + (item?.scrollWidth || 0);
+      item.setAttribute("data-required-width", usedWidth.toString(10));
+    });
+
+    return () => {
+      const menuWidth = menu.clientWidth;
+      items.forEach((item) => {
+        item.classList.remove("hidden");
+
+        if (
+          parseInt(item.getAttribute("data-required-width") || "0", 10) >=
+          menuWidth
+        ) {
+          item.classList.add("hidden");
+        }
+      });
+    };
+  }
+
+  for (const menu of prioritizedMenus) {
+    const updateVisibility = updateVisibilityFactory(menu);
+    if (!updateVisibility) {
+      continue;
+    }
+    window.addEventListener("resize", updateVisibility);
+    window.addEventListener("load", updateVisibility);
+  }
+</script>
+
+<ul
+  class={classNames}
+  data-component="header-navigation"
+  data-prioritized={prioritized ? "true" : "false"}
+>
+  {
+    navigationItems.map(({ title, path, items }, index) => (
+      <NavItemComponent
+        title={title}
+        path={path}
+        items={items}
+        mode={mode}
+        subAlignment={index === lastItemIndex ? "right" : "left"}
+      />
+    ))
+  }
+</ul>

--- a/src/components/HeaderNavigation.astro
+++ b/src/components/HeaderNavigation.astro
@@ -4,7 +4,7 @@ import NavItemComponent from "./navigation/NavItem.astro";
 
 interface Props {
   navigationItems: NavItem[];
-  mode: "click" | "hover";
+  hamburger?: boolean;
   prioritized?: boolean;
   class?: string;
 }
@@ -12,8 +12,8 @@ interface Props {
 const {
   navigationItems,
   class: classNames = "",
-  mode,
   prioritized = false,
+  hamburger = false,
 } = Astro.props;
 
 const lastItemIndex = navigationItems.length - 1;
@@ -80,7 +80,8 @@ const lastItemIndex = navigationItems.length - 1;
         title={title}
         path={path}
         items={items}
-        mode={mode}
+        hamburger={hamburger}
+        interactionMode={hamburger ? "click" : "hover"}
         subAlignment={index === lastItemIndex ? "right" : "left"}
       />
     ))

--- a/src/components/HeaderNavigation.astro
+++ b/src/components/HeaderNavigation.astro
@@ -33,26 +33,16 @@ const lastItemIndex = navigationItems.length - 1;
       return;
     }
 
-    // Store actual required width for each item, doing this initially
-    // avoids need for overflow style on container
-    // Adjust initial value to add preferred extra margin
-    let usedWidth = 0;
-    items.forEach((item) => {
-      // Adjust value to account for margin on each item
-      const margin = 24;
-      usedWidth += margin + (item?.scrollWidth || 0);
-      item.setAttribute("data-required-width", usedWidth.toString(10));
-    });
-
     return () => {
       const menuWidth = menu.clientWidth;
+      // Adjust values to add preferred extra margins
+      const margin = 24;
+      let usedWidth = 50;
       items.forEach((item) => {
         item.classList.remove("hidden");
+        usedWidth += margin + (item?.scrollWidth || 0);
 
-        if (
-          parseInt(item.getAttribute("data-required-width") || "0", 10) >=
-          menuWidth
-        ) {
+        if (usedWidth >= menuWidth) {
           item.classList.add("hidden");
         }
       });

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -1,37 +1,34 @@
 ---
-export interface Props {
-  title: string;
-  path?: string;
-  subAlignment?: "left" | "right";
-  subItems?: SubItem[];
+import type { NavItem } from "../../types";
+export interface Props extends NavItem {
   class?: string;
-}
-interface SubItem {
-  title: string;
-  path: string;
+  subAlignment?: "left" | "right";
+  mode?: "click" | "hover";
 }
 
 const {
   title,
   path,
-  subItems = [],
+  items = [],
   subAlignment = "left",
   class: className = "",
+  mode = "click",
 } = Astro.props;
+
 const key = `${title.toLowerCase().replace(" ", "-")}-${path || ""}`;
 const clickable = !!path;
-const expandable = !!subItems.length;
+const expandable = !!items.length;
 
 const TextContainer = clickable ? "a" : "span";
 const isActive =
   path === Astro.url.pathname ||
-  subItems.some((item) => item.path === Astro.url.pathname);
+  items.some((item) => item.path === Astro.url.pathname);
 
-const subItemsWithParent: Array<
-  SubItem & {
+const itemsWithParent: Array<
+  NavItem & {
     touchOnly?: boolean;
   }
-> = path ? [{ path, title, touchOnly: true }, ...subItems] : subItems;
+> = path ? [{ path, title, touchOnly: true }, ...items] : items;
 ---
 
 <script>
@@ -41,9 +38,6 @@ const subItemsWithParent: Array<
     subMenu: HTMLElement;
     navItem: HTMLElement;
   }
-
-  const isTouchDevice =
-    "ontouchstart" in window || navigator.maxTouchPoints > 0;
 
   const navItems: SubNavComponents[] = [
     ...document.querySelectorAll("[data-component='nav-item']"),
@@ -77,23 +71,10 @@ const subItemsWithParent: Array<
   }
 
   navItems.forEach(({ mainLink, navItem, trigger, subMenu }, index: number) => {
-    navItem.classList.toggle("touch-device", isTouchDevice);
+    const interactionMode = navItem.getAttribute("data-mode") || "click";
+    navItem.classList.add(`interaction-mode-${interactionMode}`);
 
-    if (isTouchDevice) {
-      subMenu.querySelectorAll(".hidden").forEach((subMenu) => {
-        subMenu.classList.remove("hidden");
-      });
-      [mainLink, trigger].forEach((item) =>
-        item?.addEventListener("click", (event) => {
-          event?.preventDefault();
-          const expanded = !(
-            trigger.getAttribute("aria-expanded") === "true" || false
-          );
-          closeAll();
-          expand(index, expanded);
-        }),
-      );
-    } else {
+    if (interactionMode === "hover") {
       navItem.addEventListener("mouseenter", () => {
         closeAll();
         expand(index, true);
@@ -101,13 +82,29 @@ const subItemsWithParent: Array<
       navItem.addEventListener("mouseleave", () => {
         expand(index, false);
       });
+      return;
     }
+
+    subMenu.querySelectorAll(".hidden").forEach((subMenu) => {
+      subMenu.classList.remove("hidden");
+    });
+    [mainLink, trigger].forEach((item) =>
+      item?.addEventListener("click", (event) => {
+        event?.preventDefault();
+        const expanded = !(
+          trigger.getAttribute("aria-expanded") === "true" || false
+        );
+        closeAll();
+        expand(index, expanded);
+      }),
+    );
   });
 </script>
 
 <li
   class={`relative group bg-backgroundSecondary ${className}`}
   data-component="nav-item"
+  data-mode={mode}
 >
   <div
     class={`block ${isActive ? "text-orange-500" : "text-white"} ${clickable ? "group-[.expanded]:text-orange-500" : "group-[.expanded]:text-neutral-400"} flex z-10 relative ${clickable ? "cursor-pointer" : "cursor-default"} items-center h-6`}
@@ -122,7 +119,7 @@ const subItemsWithParent: Array<
           data-part="trigger"
           aria-controls={`nav-item-sub-${key}`}
           aria-expanded="false"
-          class="block p-1 ml-auto rounded group-[.touch-device]:bg-neutral-800"
+          class="block p-1 ml-auto rounded group-[.interaction-mode-click]:bg-neutral-800"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -155,7 +152,7 @@ const subItemsWithParent: Array<
         aria-role="menu"
         data-part="sub-menu"
       >
-        {subItemsWithParent.map((subItem) => (
+        {itemsWithParent.map((subItem) => (
           <li class={`${subItem.touchOnly ? "hidden" : ""}`}>
             <a
               href={subItem.path}

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -72,11 +72,17 @@ const itemsWithParent: Array<
     });
   }
 
+  const isTouchDevice =
+    "ontouchstart" in window ||
+    navigator.maxTouchPoints > 0 ||
+    // @ts-ignore
+    navigator.msMaxTouchPoints > 0;
+
   navItems.forEach(({ mainLink, navItem, trigger, subMenu }, index: number) => {
     const interactionMode = navItem.getAttribute("data-mode") || "click";
     navItem.classList.add(`interaction-mode-${interactionMode}`);
 
-    if (interactionMode === "hover") {
+    if (interactionMode === "hover" && !isTouchDevice) {
       navItem.addEventListener("mouseenter", () => {
         closeAll();
         expand(index, true);

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -3,7 +3,8 @@ import type { NavItem } from "../../types";
 export interface Props extends NavItem {
   class?: string;
   subAlignment?: "left" | "right";
-  mode?: "click" | "hover";
+  interactionMode?: "click" | "hover";
+  hamburger?: boolean;
 }
 
 const {
@@ -12,7 +13,8 @@ const {
   items = [],
   subAlignment = "left",
   class: className = "",
-  mode = "click",
+  interactionMode = "click",
+  hamburger = false,
 } = Astro.props;
 
 const key = `${title.toLowerCase().replace(" ", "-")}-${path || ""}`;
@@ -104,7 +106,7 @@ const itemsWithParent: Array<
 <li
   class={`relative group bg-backgroundSecondary ${className}`}
   data-component="nav-item"
-  data-mode={mode}
+  data-mode={interactionMode}
 >
   <div
     class={`block ${isActive ? "text-orange-500" : "text-white"} ${clickable ? "group-[.expanded]:text-orange-500" : "group-[.expanded]:text-neutral-400"} flex z-10 relative ${clickable ? "cursor-pointer" : "cursor-default"} items-center h-6`}
@@ -147,7 +149,12 @@ const itemsWithParent: Array<
   {
     expandable ? (
       <ul
-        class={`hidden min-w-max flex-col bg-neutral-800 md:bg-backgroundSecondary space-y-1 px-2 py-3 mt-3 z-0 md:mt-0 md:pt-10 md:rounded-b-md md:absolute md:top-0 ${subAlignment === "left" ? "md:left-0" : "md:right-0"}`}
+        class:list={[
+          "hidden min-w-max flex-col bg-neutral-800  space-y-1 px-2 py-3 mt-3 z-0",
+          !hamburger &&
+            "md:mt-0 md:pt-10 md:rounded-b-md md:absolute md:top-0 md:bg-backgroundSecondary",
+          subAlignment === "left" ? "md:left-0" : "md:right-0",
+        ]}
         id={`nav-item-sub-${key}`}
         aria-role="menu"
         data-part="sub-menu"

--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -115,9 +115,9 @@ const itemsWithParent: Array<
   data-mode={interactionMode}
 >
   <div
-    class={`block ${isActive ? "text-orange-500" : "text-white"} ${clickable ? "group-[.expanded]:text-orange-500" : "group-[.expanded]:text-neutral-400"} flex z-10 relative ${clickable ? "cursor-pointer" : "cursor-default"} items-center h-6`}
+    class={`block ${isActive ? "text-orange-500" : "text-white"} ${clickable ? "group-[.expanded]:text-orange-500" : "group-[.expanded]:text-neutral-400"} flex ${interactionMode === "hover" ? "z-20" : ""} relative ${clickable ? "cursor-pointer" : "cursor-default"} items-center h-6`}
   >
-    <TextContainer href={path} data-part="main-link" class="mr-3 w-full">
+    <TextContainer href={path} data-part="main-link" class="mr-3 w-max">
       {title}
     </TextContainer>
     {
@@ -156,10 +156,11 @@ const itemsWithParent: Array<
     expandable ? (
       <ul
         class:list={[
-          "hidden min-w-max flex-col bg-neutral-800  space-y-1 px-2 py-3 mt-3 z-0",
-          !hamburger &&
-            "md:mt-0 md:pt-10 md:rounded-b-md md:absolute md:top-0 md:bg-backgroundSecondary",
-          subAlignment === "left" ? "md:left-0" : "md:right-0",
+          "hidden min-w-max w-full flex-col space-y-1 px-2 py-3",
+          hamburger
+            ? "mt-3 bg-neutral-800"
+            : "z-10 mt-0 pt-10 rounded-b-md absolute top-0 bg-backgroundSecondary",
+          subAlignment === "left" ? "left-0" : "right-0",
         ]}
         id={`nav-item-sub-${key}`}
         aria-role="menu"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./articles";
 export * from "./images";
+export * from "./navigation";

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,7 @@
+export interface MinimalNavItem {
+  title: string;
+  path?: string;
+}
+export interface NavItem extends MinimalNavItem {
+  items?: MinimalNavItem[];
+}


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/114

Still a couple of quirks to iron out, but should (🤞) fix issue goals. Logic is
- Show top navbar items from `md` and up, gradually showing more items as needed (hide rightmost item when out of space)
- Show hamburger for all sizes, always including all menu items
- Switch all navigation items from hover to click/tap/toggle on touch devices
- ...

## A couple of examples

Desktop with room for all top items
<img width="1034" alt="Screenshot 2024-12-04 at 00 15 03" src="https://github.com/user-attachments/assets/2557c961-6205-4019-98db-19fcc4abdd27">

... with expanded hamburger
<img width="1034" alt="Screenshot 2024-12-04 at 00 15 15" src="https://github.com/user-attachments/assets/aa1069fc-84d8-4502-aa8c-524586496f7a">

... with hovered nav item
<img width="1032" alt="Screenshot 2024-12-04 at 00 15 26" src="https://github.com/user-attachments/assets/45b93958-dca6-4411-bfb8-8b5f508f11e8">

Slightly smaller viewport with nav items hidden
<img width="666" alt="Screenshot 2024-12-04 at 00 15 50" src="https://github.com/user-attachments/assets/54791c35-1654-49ca-a766-fa4bc385ef87">

Smallest (mobile) breakpoint with only hamburger menu
<img width="375" alt="Screenshot 2024-12-04 at 00 16 13" src="https://github.com/user-attachments/assets/c6097fac-3778-4ac5-a6dc-e71688501001">

... with expanded hamburger
<img width="374" alt="Screenshot 2024-12-04 at 00 16 23" src="https://github.com/user-attachments/assets/712c1461-ea30-4340-ba0b-2fb919f2206c">