### PR TITLE
feat: add tg25 logo to header

### DIFF
--- a/public/tg25/tg25_horizontal_white.svg
+++ b/public/tg25/tg25_horizontal_white.svg
@@ -1,0 +1,507 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1015.8442"
+   height="403.297"
+   viewBox="0 0 1015.8443 403.297"
+   sodipodi:docname="tg25_horizontal_white.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="0.23231884"
+     inkscape:cx="505.77042"
+     inkscape:cy="225.98253"
+     inkscape:window-width="1512"
+     inkscape:window-height="916"
+     inkscape:window-x="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <defs
+     id="defs1">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="matrix(1,0,0,-1,-40.690401,63.986302)"
+         id="path9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="matrix(1,0,0,-1,-279.59671,67.736804)"
+         id="path11" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-12.631764,20.57172,20.57172,12.631764,123.54401,292.0752)"
+       spreadMethod="pad"
+       id="linearGradient13">
+      <stop
+         style="stop-opacity:1;stop-color:#f37721"
+         offset="0"
+         id="stop12" />
+      <stop
+         style="stop-opacity:1;stop-color:#f9a51a"
+         offset="1"
+         id="stop13" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-91.492105,-245.18381)"
+         id="path15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-76.571702,-224.73671)"
+         id="path17" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-128.21564,72.703194,72.703194,128.21564,213.79953,161.30295)"
+       spreadMethod="pad"
+       id="linearGradient18">
+      <stop
+         style="stop-opacity:1;stop-color:#f37721"
+         offset="0"
+         id="stop17" />
+      <stop
+         style="stop-opacity:1;stop-color:#f9a51a"
+         offset="1"
+         id="stop18" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath20">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-170.2177,-335.99081)"
+         id="path20" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-140.7016,-252.7653)"
+         id="path22" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.0145144,134.08693,134.08693,-6.0145144,249.93239,159.56186)"
+       spreadMethod="pad"
+       id="linearGradient23">
+      <stop
+         style="stop-opacity:1;stop-color:#0ca5c7"
+         offset="0"
+         id="stop22" />
+      <stop
+         style="stop-opacity:1;stop-color:#44c7f4"
+         offset="1"
+         id="stop23" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath25">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-263.07411,-298.09651)"
+         id="path25" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-262.6378,-310.65211)"
+         id="path27" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-29.504917,-77.360527,-77.360527,29.504917,179.25247,330.27441)"
+       spreadMethod="pad"
+       id="linearGradient28">
+      <stop
+         style="stop-opacity:1;stop-color:#0ca5c7"
+         offset="0"
+         id="stop27" />
+      <stop
+         style="stop-opacity:1;stop-color:#44c7f4"
+         offset="1"
+         id="stop28" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath30">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-209.5645,-245.09631)"
+         id="path30" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(26.061132,6.7830253,6.7830253,-26.061132,173.62512,230.90192)"
+       spreadMethod="pad"
+       id="linearGradient31">
+      <stop
+         style="stop-opacity:1;stop-color:#0ca5c7"
+         offset="0"
+         id="stop30" />
+      <stop
+         style="stop-opacity:1;stop-color:#44c7f4"
+         offset="1"
+         id="stop31" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-303.82961,-208.4496)"
+         id="path33" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-371.27701,-222.43011)"
+         id="path35" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-424.28181,-264.04971)"
+         id="path37" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-481.57131,-162.6521)"
+         id="path39" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath41">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-511.08862,-162.6521)"
+         id="path41" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-575.04461,-222.43011)"
+         id="path43" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath45">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-686.50181,-278.03011)"
+         id="path45" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-738.71332,-208.4496)"
+         id="path47" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath49">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-635.03272,-278.03011)"
+         id="path49" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath51">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-619.79711,-247.14491)"
+         id="path51" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath53">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-286.2211,-332.34111)"
+         id="path53" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath55">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-308.38941,-293.10491)"
+         id="path55" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath57">
+      <path
+         d="M 0,337.751 H 761.884 V 0 H 0 Z"
+         transform="translate(-319.81131,-293.10491)"
+         id="path57" />
+    </clipPath>
+  </defs>
+  <g
+     id="g1"
+     transform="translate(-1.397164e-4,-1.3513663e-5)">
+    <g
+       id="group-MC0" />
+    <g
+       id="group-MC1">
+      <path
+         id="path2"
+         d="M 0,0 V -109.001 H 26 V -99 H 10 v 87.999 H 26 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,0.3168,257.96267)" />
+      <path
+         id="path3"
+         d="M 0,0 V -11 H 16 V -99 H 0 v -10 H 26 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,315.73467,257.9632)" />
+      <path
+         id="path4"
+         d="m 0,0 -11.021,-10.049 h -19.417 v 20 h 19.837 z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,232.90067,331.23147)" />
+      <path
+         id="path5"
+         d="m 0,0 11.021,-10.049 h 19.417 v 20 H 10.601 Z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,247.732,331.23147)" />
+      <path
+         id="path6"
+         d="M 0,0 10.049,10.993 V 30.36 h -20 V 10.574 Z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,240.25147,325.1104)" />
+      <path
+         id="path7"
+         d="M 0,0 10.049,-10.993 V -30.36 h -20 v 19.786 z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,240.25147,338.816)" />
+      <path
+         id="path8"
+         d="M 5.6250297,-54.984427 H 25.101592 c 4.3125,0 7.866211,0.503907 10.664063,1.511719 2.794922,1.001953 4.992187,2.308594 6.585937,3.925781 1.59375,1.617188 2.695313,3.416016 3.304688,5.390625 0.615234,1.97754 0.925781,3.914063 0.925781,5.8125 0,3.539063 -0.641602,6.515625 -1.921875,8.929688 -1.283203,2.414062 -3.439453,4.441406 -6.46875,6.082031 L 49.359405,-5.15625e-5 H 36.960967 L 27.726592,-20.63677 H 16.945342 V -5.15625e-5 H 5.6250297 Z M 25.87503,-30.187552 c 1.795898,0 3.284179,-0.190429 4.464843,-0.574218 1.177735,-0.38086 2.115235,-0.919922 2.8125,-1.617188 0.694336,-0.694336 1.166016,-1.529297 1.417969,-2.507812 0.257813,-0.975586 0.386719,-2.053711 0.386719,-3.234375 0,-0.966797 -0.158203,-1.901367 -0.46875,-2.800782 -0.304688,-0.896484 -0.829102,-1.693359 -1.570313,-2.390625 -0.74414,-0.694335 -1.769531,-1.233398 -3.082031,-1.617187 -1.30664,-0.380859 -2.961914,-0.574219 -4.96875,-0.574219 h -7.921875 v 15.316406 z m 30.032226,-24.796875 h 37.5 v 9.785157 H 67.379913 v 12.011718 h 24.480468 v 9.855469 H 67.379913 V -9.7852078 H 95.024444 L 93.864288,-5.15625e-5 H 55.907256 Z m 0,0"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         aria-label="RE"
+         transform="matrix(1.3333333,0,0,1.3333333,54.253867,365.0196)"
+         clip-path="url(#clipPath9)" />
+      <path
+         id="path10"
+         d="m 13.207988,-13.440958 c 0.375,2.484375 1.371093,4.1074221 2.988281,4.8632814 1.623047,0.75 3.568359,1.125 5.835937,1.125 2.701172,0 4.631836,-0.3339843 5.789063,-1.0078125 1.163086,-0.6796875 1.746094,-1.7724609 1.746094,-3.2812499 0,-1.078125 -0.369141,-2.021484 -1.101563,-2.835938 -0.726562,-0.811523 -2.115234,-1.376953 -4.160156,-1.699218 l -5.835938,-0.972657 c -5.132812,-0.811523 -8.9589841,-2.203125 -11.472656,-4.171875 -2.5078125,-1.974609 -3.7617187,-4.95996 -3.7617187,-8.953125 0,-2.05371 0.4453125,-3.890625 1.3359375,-5.507812 0.8964843,-1.617188 2.15625,-2.991211 3.7734375,-4.125 1.6171875,-1.139648 3.5449217,-2.018555 5.7890627,-2.636719 2.241211,-0.624023 4.713867,-0.9375 7.417969,-0.9375 3.342773,0 6.146484,0.339844 8.414062,1.019531 2.273438,0.673829 4.125,1.576172 5.554688,2.707032 1.429687,1.133789 2.507812,2.484375 3.234375,4.054687 0.732421,1.564453 1.259765,3.234375 1.582031,5.015625 l -10.125,1.300781 c -0.486328,-1.945312 -1.335938,-3.375 -2.554688,-4.289062 -1.21289,-0.919922 -3.169922,-1.382813 -5.871093,-1.382813 -1.50879,0 -2.762696,0.123047 -3.761719,0.363282 -1.001953,0.243164 -1.78711,0.55664 -2.355469,0.9375 -0.5625,0.375 -0.966797,0.808593 -1.207031,1.300781 -0.243164,0.486328 -0.363281,0.943359 -0.363281,1.371094 0,1.353515 0.416015,2.34082 1.253906,2.964843 0.834961,0.618165 2.466797,1.142579 4.898437,1.570313 l 5.34375,0.890625 c 2.967774,0.486328 5.425782,1.107422 7.371094,1.863281 1.945313,0.758789 3.495117,1.69336 4.652344,2.800781 1.163086,1.101563 1.974609,2.411133 2.4375,3.925782 0.459961,1.508789 0.691406,3.263672 0.691406,5.261718 0,3.9931645 -1.511719,7.1923833 -4.535156,9.5976567 -3.023438,2.40527343 -7.696289,3.609375 -14.015625,3.609375 -2.540039,0 -4.957031,-0.2314453 -7.253906,-0.69140626 C 12.651347,0.14693281 10.600566,-0.6470125 8.7900188,-1.7808016 6.9765422,-2.9116609 5.4882609,-4.4233797 4.325175,-6.3159578 3.1679484,-8.2056062 2.5087688,-10.581583 2.3447063,-13.440958 Z m 37.907226,-20.015625 h -6.644531 v -8.824219 h 6.644531 V -53.54252 h 11.332031 v 11.261718 h 9.726563 v 8.824219 h -9.726563 v 19.523438 c 0,2.220703 0.457032,3.720703 1.371094,4.4999997 0.919922,0.7822266 2.112305,1.171875 3.574219,1.171875 0.755859,0 1.526367,-0.038086 2.308594,-0.1171875 0.779296,-0.084961 1.549804,-0.234375 2.308593,-0.4453125 l 1.617188,8.34374999 c -1.564453,0.48339844 -3.087891,0.8203125 -4.570313,1.0078125 -1.485351,0.1875 -2.90332,0.28125 -4.253906,0.28125 -4.649414,0 -8.094726,-1.10449219 -10.335937,-3.31640629 C 52.231425,-4.7251375 51.115214,-8.4517 51.115214,-13.687052 Z M 104.3242,-5.3433016 c -1.67285,1.8925782 -3.54785,3.4306641 -5.625002,4.61718754 -2.080078,1.18652344 -4.766601,1.78124996 -8.0625,1.78124996 -1.892578,0 -3.688476,-0.24609371 -5.390625,-0.73828121 -1.696289,-0.48339844 -3.18164,-1.23632813 -4.453125,-2.26171879 -1.265625,-1.0224609 -2.279296,-2.3320312 -3.035156,-3.9257812 -0.758789,-1.59375 -1.136719,-3.4951172 -1.136719,-5.7070317 0,-2.920898 0.647461,-5.299804 1.945313,-7.136718 1.294922,-1.833985 2.994141,-3.263672 5.097656,-4.289063 2.109375,-1.022461 4.470703,-1.749023 7.089844,-2.179687 2.625,-0.436524 5.285156,-0.708985 7.980469,-0.820313 l 5.425785,-0.234375 v -2.109375 c 0,-2.592773 -0.71485,-4.374023 -2.14454,-5.34375 -1.42968,-0.975586 -3.117183,-1.464844 -5.062495,-1.464844 -4.476563,0 -7.040039,1.705079 -7.6875,5.109375 l -10.371094,-0.972656 c 0.755859,-4.429687 2.698242,-7.628906 5.824219,-9.597656 3.131836,-1.974609 7.347656,-2.964844 12.644531,-2.964844 3.240239,0 5.994139,0.395508 8.261719,1.183594 2.26465,0.782227 4.08398,1.904297 5.46094,3.363281 1.38281,1.453125 2.38183,3.219727 3,5.296875 0.62402,2.080078 0.9375,4.415039 0.9375,7.007813 V 4.484375e-4 H 104.3242 Z m -0.23438,-13.5234374 -5.02734,0.234375 c -2.375977,0.111328 -4.294922,0.357422 -5.753907,0.738281 -1.453125,0.375 -2.575195,0.84961 -3.363281,1.417969 -0.782226,0.5625 -1.30957,1.224609 -1.582031,1.980469 -0.266602,0.758789 -0.398438,1.59375 -0.398438,2.507812 0,1.40625 0.483399,2.5166018 1.453125,3.3281252 0.975586,0.8056641 2.326172,1.2070312 4.054688,1.2070312 2.912109,0 5.288086,-0.6738281 7.125004,-2.0273437 1.03125,-0.7499997 1.86914,-1.7050777 2.51953,-2.8710937 0.64746,-1.163086 0.97265,-2.607422 0.97265,-4.335938 z m 20.5752,-23.414063 h 11.01562 v 5.917969 c 1.39746,-2.217773 3.09668,-3.878906 5.09766,-4.980469 1.99805,-1.107421 4.10449,-1.664062 6.31641,-1.664062 1.07812,0 1.96875,0.04102 2.67187,0.117187 0.70313,0.0791 1.32422,0.172852 1.86328,0.28125 l -1.37109,10.289063 c -1.29785,-0.319336 -2.8916,-0.480469 -4.78125,-0.480469 -1.24219,0 -2.43164,0.149414 -3.5625,0.445313 -1.13379,0.298828 -2.16211,0.849609 -3.08203,1.652343 -0.96973,0.867188 -1.68457,1.839844 -2.14453,2.917969 -0.46289,1.078125 -0.69141,2.188477 -0.69141,3.328125 V 4.484375e-4 h -11.33203 z m 38.14746,8.824219 h -6.64453 v -8.824219 h 6.64453 V -53.54252 h 11.33203 v 11.261718 h 9.72656 v 8.824219 h -9.72656 v 19.523438 c 0,2.220703 0.45703,3.720703 1.37109,4.4999997 0.91993,0.7822266 2.11231,1.171875 3.57422,1.171875 0.75586,0 1.52637,-0.038086 2.3086,-0.1171875 0.77929,-0.084961 1.5498,-0.234375 2.30859,-0.4453125 l 1.61719,8.34374999 c -1.56445,0.48339844 -3.08789,0.8203125 -4.57031,1.0078125 -1.48536,0.1875 -2.90332,0.28125 -4.25391,0.28125 -4.64941,0 -8.09473,-1.10449219 -10.33594,-3.31640629 -2.23535,-2.2177734 -3.35156,-5.9443359 -3.35156,-11.1796879 z m 0,0"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         aria-label="start"
+         transform="matrix(1.3333333,0,0,1.3333333,372.7956,360.01893)"
+         clip-path="url(#clipPath11)" />
+      <path
+         id="path12"
+         d="M 0,0 0.041,0.057 Z"
+         style="fill:#f3782a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,121.9896,123.52187)" />
+      <path
+         id="path13"
+         d="m 139.293,310.278 18.516,25.374 H 126.54 L 91.533,244.828 Z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,450.33467)"
+         style="fill:url(#linearGradient13);stroke:none" />
+      <path
+         id="path14"
+         d="M 0,0 0.041,0.057 35.048,90.881 C 25.75,78.139 -79.131,-65.592 -91.492,-82.532 h 31.268 C -49.353,-67.634 -10.122,-13.872 0,0"
+         style="fill:#f37721;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,121.98947,123.42293)"
+         clip-path="url(#clipPath15)" />
+      <path
+         id="path16"
+         d="m 0,0 83.895,-62.085 h 42.55 z"
+         style="fill:#f37721;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,102.0956,150.68573)"
+         clip-path="url(#clipPath17)" />
+      <path
+         id="path18"
+         d="M 76.572,224.662 203.017,162.578 91.492,245.11 Z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,450.33467)"
+         style="fill:url(#linearGradient18);stroke:none" />
+      <path
+         id="path19"
+         d="m 0,0 -57.258,-78.467 0.031,-0.023 -7.482,-10.254 35.193,5.444 z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,226.95693,2.3469333)"
+         clip-path="url(#clipPath20)" />
+      <path
+         id="path21"
+         d="M 0,0 -35.193,-5.445 79.219,-90.113 h 42.717 C 105.567,-78.182 18.169,-13.436 0,0"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,187.60213,113.31427)"
+         clip-path="url(#clipPath22)" />
+      <path
+         id="path23"
+         d="m 237.877,180.776 25.197,-18.198 v 135.518 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,450.33467)"
+         style="fill:url(#linearGradient23);stroke:none" />
+      <path
+         id="path24"
+         d="m 0,0 h -73.98 v -0.044 l -0.015,0.012 -33.024,-44.976 34.921,5.341 10.769,14.667 h 36.349 v -92.658 z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,350.76547,52.872667)"
+         clip-path="url(#clipPath25)" />
+      <path
+         id="path26"
+         d="M 0,0 V 25 H -92.42 L -79.668,0 Z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,350.18373,36.131867)"
+         clip-path="url(#clipPath27)" />
+      <path
+         id="path28"
+         d="m 140.701,252.691 42.269,57.926 -12.752,25.374 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,450.33467)"
+         style="fill:url(#linearGradient28);stroke:none" />
+      <path
+         id="path29"
+         d="M 0,0 -18.088,13.386 0,-31.489 Z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,279.41933,123.5396)"
+         clip-path="url(#clipPath30)" />
+      <path
+         id="path31"
+         d="m 156.314,253.06 53.312,-39.452 -18.088,44.874 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,450.33467)"
+         style="fill:url(#linearGradient31);stroke:none" />
+      <path
+         id="path32"
+         d="M 0,0 V 13.98 H 23.17 V -45.798 H -6.666 c -11.743,0 -17.615,6.481 -17.615,19.444 v 76.169 c 0,13.177 5.872,19.765 17.615,19.765 H 3.809 c 12.907,0 19.361,-6.696 19.361,-20.086 V 36.96 H 7.935 v 10.284 c 0,5.569 -2.17,8.356 -6.507,8.356 h -3.809 c -4.443,0 -6.665,-2.787 -6.665,-8.356 v -70.705 c 0,-5.572 2.222,-8.356 6.665,-8.356 H 7.935 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,405.10613,172.40187)"
+         clip-path="url(#clipPath33)" />
+      <path
+         id="path34"
+         d="m 0,0 v 34.87 c 0,4.5 -2.222,6.75 -6.666,6.75 h -4.126 c -4.444,0 -6.665,-2.25 -6.665,-6.75 V 0 Z m -17.457,-59.778 h -15.236 v 95.612 c 0,13.178 6.083,19.766 18.251,19.766 h 11.427 c 12.165,0 18.25,-6.588 18.25,-19.766 V -59.778 H 0 v 45.798 h -17.457 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,495.036,153.7612)"
+         clip-path="url(#clipPath35)" />
+      <path
+         id="path36"
+         d="M 0,0 V -101.398 H -15.235 V 0 H -29.836 V 13.98 H 14.601 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,565.70907,98.2684)"
+         clip-path="url(#clipPath37)" />
+      <path
+         id="path38"
+         d="M 0,0 V 45.798 H -18.727 V 0 h -15.235 v 115.378 h 15.235 v -55.6 H 0 v 55.6 H 15.236 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,642.09507,233.4652)"
+         clip-path="url(#clipPath39)" />
+      <path
+         id="path40"
+         d="m 0,0 v 115.378 h 37.771 v -13.98 H 15.236 V 59.778 H 35.232 V 45.798 H 15.236 V 13.98 H 37.771 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,681.45147,233.4652)"
+         clip-path="url(#clipPath41)" />
+      <path
+         id="path42"
+         d="m 0,0 h 9.998 c 4.548,0 6.824,2.785 6.824,8.356 v 24.907 c 0,5.57 -2.276,8.357 -6.824,8.357 H 0 Z m -15.236,55.6 h 29.837 c 11.637,0 17.457,-6.588 17.457,-19.766 V 7.392 c 0,-10.071 -3.015,-16.446 -9.046,-19.123 L 33.645,-59.778 H 19.203 L 9.205,-13.177 H 0 v -46.601 h -15.236 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,766.72613,153.7612)"
+         clip-path="url(#clipPath43)" />
+      <path
+         id="path44"
+         d="M 0,0 V -74.081 L -21.952,0 h -12.238 -2.998 v -115.378 h 15.236 v 74.081 L 0,-115.378 h 12.237 2.999 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,915.33573,79.627867)"
+         clip-path="url(#clipPath45)" />
+      <path
+         id="path46"
+         d="M 0,0 V 13.98 H 23.17 V -45.798 H -6.666 c -11.743,0 -17.615,6.481 -17.615,19.444 v 76.169 c 0,13.177 5.872,19.765 17.615,19.765 H 3.809 c 12.907,0 19.361,-6.696 19.361,-20.086 V 36.96 H 7.935 v 10.284 c 0,5.569 -2.17,8.356 -6.507,8.356 h -3.809 c -4.443,0 -6.665,-2.787 -6.665,-8.356 v -70.705 c 0,-5.572 2.222,-8.356 6.665,-8.356 H 7.935 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,984.95107,172.40187)"
+         clip-path="url(#clipPath47)" />
+      <path
+         id="path48"
+         d="M 0,0 H -15.236 V -25.993 L 0,-12.631 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,846.71027,79.627867)"
+         clip-path="url(#clipPath49)" />
+      <path
+         id="path50"
+         d="M 0,0 V -84.493 H 15.236 V 13.362 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,826.39613,120.80813)"
+         clip-path="url(#clipPath51)" />
+      <path
+         id="path52"
+         d="M 0,0 V -39.236 H -5.895 V 0 h -5.65 V 5.41 H 5.65 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,381.62813,7.2132)"
+         clip-path="url(#clipPath53)" />
+      <path
+         id="path54"
+         d="M 0,0 V 17.721 H -7.246 V 0 h -5.896 v 44.646 h 5.896 V 23.131 H 0 V 44.646 H 5.895 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,411.18587,59.528133)"
+         clip-path="url(#clipPath55)" />
+      <path
+         id="path56"
+         d="m 0,0 v 44.646 h 14.616 v -5.41 H 5.895 V 23.131 h 7.738 v -5.41 H 5.895 V 5.41 h 8.721 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,426.41507,59.528133)"
+         clip-path="url(#clipPath57)" />
+    </g>
+  </g>
+</svg>

--- a/public/tg25/tg25_icon_white.svg
+++ b/public/tg25/tg25_icon_white.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="96"
+   height="94.666664"
+   viewBox="0 0 96 94.666664"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="g1">
+    <g
+       id="group-MC0" />
+    <g
+       id="group-MC1">
+      <path
+         id="path2"
+         d="M 0,0 V -20 H 19.417 L 30.438,-9.951 19.837,0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,33.333467)" />
+      <path
+         id="path3"
+         d="M 0,0 -10.6,-9.951 0.42,-20 H 19.838 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,69.5496,33.333467)" />
+      <path
+         id="path4"
+         d="M 0,0 V -19.786 L 9.951,-30.361 20,-19.368 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,34.6668,-1.3333333e-4)" />
+      <path
+         id="path5"
+         d="M 0,0 V -19.786 H 20 V -0.419 L 9.951,10.574 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,34.6668,68.284667)" />
+    </g>
+  </g>
+</svg>

--- a/public/tg25/tg25_square_white.svg
+++ b/public/tg25/tg25_square_white.svg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="350.76532"
+   height="399.50934"
+   viewBox="0 0 350.76532 399.50934"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-12.631764,20.57172,20.57172,12.631764,123.54401,255.64249)"
+       spreadMethod="pad"
+       id="linearGradient10">
+      <stop
+         style="stop-opacity:1;stop-color:#f37721"
+         offset="0"
+         id="stop9" />
+      <stop
+         style="stop-opacity:1;stop-color:#f9a51a"
+         offset="1"
+         id="stop10" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath12">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-91.492105,-208.75111)"
+         id="path12" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath14">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-76.571702,-188.30401)"
+         id="path14" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-128.21564,72.703194,72.703194,128.21564,213.79953,124.87025)"
+       spreadMethod="pad"
+       id="linearGradient15">
+      <stop
+         style="stop-opacity:1;stop-color:#f37721"
+         offset="0"
+         id="stop14" />
+      <stop
+         style="stop-opacity:1;stop-color:#f9a51a"
+         offset="1"
+         id="stop15" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-170.2177,-299.55811)"
+         id="path17" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath19">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-140.7016,-216.3326)"
+         id="path19" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(6.0145144,134.08693,134.08693,-6.0145144,249.93239,123.12917)"
+       spreadMethod="pad"
+       id="linearGradient20">
+      <stop
+         style="stop-opacity:1;stop-color:#0ca5c7"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-opacity:1;stop-color:#44c7f4"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-263.07411,-261.66381)"
+         id="path22" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-262.6378,-274.21941)"
+         id="path24" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-29.504917,-77.360527,-77.360527,29.504917,179.25247,293.84171)"
+       spreadMethod="pad"
+       id="linearGradient25">
+      <stop
+         style="stop-opacity:1;stop-color:#0ca5c7"
+         offset="0"
+         id="stop24" />
+      <stop
+         style="stop-opacity:1;stop-color:#44c7f4"
+         offset="1"
+         id="stop25" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M 0,299.632 H 263.074 V 0 H 0 Z"
+         transform="translate(-209.5645,-208.6637)"
+         id="path27" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(26.061132,6.7830253,6.7830253,-26.061132,173.62512,194.46922)"
+       spreadMethod="pad"
+       id="linearGradient28">
+      <stop
+         style="stop-opacity:1;stop-color:#0ca5c7"
+         offset="0"
+         id="stop27" />
+      <stop
+         style="stop-opacity:1;stop-color:#44c7f4"
+         offset="1"
+         id="stop28" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g1">
+    <g
+       id="group-MC0" />
+    <g
+       id="group-MC1">
+      <path
+         id="path2"
+         d="m 0,0 v -109 h 26 v 10 H 10 v 88 H 26 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,254.17613)" />
+      <path
+         id="path3"
+         d="M 0,0 V -11 H 15.999 V -99 H 0 v -10 H 25.999 V 0 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,315.4188,254.17613)" />
+      <path
+         id="path4"
+         d="m 0,0 -11.021,-10.049 h -19.417 v 20 h 19.837 z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,232.58427,327.44427)" />
+      <path
+         id="path5"
+         d="m 0,0 11.021,-10.049 h 19.417 v 20 H 10.601 Z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,247.41547,327.44427)" />
+      <path
+         id="path6"
+         d="M 0,0 10.049,10.993 V 30.36 h -20 V 10.574 Z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,239.93493,321.3232)" />
+      <path
+         id="path7"
+         d="M 0,0 10.049,-10.993 V -30.36 h -20 v 19.786 z"
+         style="fill:#ff7100;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,239.93493,335.0288)" />
+      <path
+         id="path8"
+         d="M 31.170869,7.765625e-4 23.893525,-16.616411 c -0.688477,-1.576172 -1.646484,-2.768555 -2.871094,-3.574219 -1.227539,-0.802734 -2.671875,-1.207031 -4.335937,-1.207031 H 14.834931 V 7.765625e-4 H 5.09665 V -51.69063 h 15.070313 c 2.850585,0 5.4375,0.246094 7.757812,0.738282 2.320313,0.486328 4.294922,1.294921 5.929688,2.425781 1.631835,1.133789 2.888671,2.610351 3.773437,4.429687 0.881836,1.822266 1.324219,4.048828 1.324219,6.679688 0,1.898437 -0.278321,3.585937 -0.832031,5.0625 -0.547852,1.476562 -1.324219,2.750976 -2.332032,3.820312 -1.001953,1.072266 -2.191406,1.933594 -3.574218,2.589844 -1.382813,0.65625 -2.891602,1.119141 -4.523438,1.382813 1.265625,0.266601 2.425781,0.984375 3.480469,2.15625 1.054687,1.171875 2.109375,2.868164 3.164062,5.085937 L 42.59665,7.765625e-4 Z M 28.756806,-36.467973 c 0,-2.53125 -0.805664,-4.347657 -2.414062,-5.449219 -1.611328,-1.107422 -4.025391,-1.664063 -7.242188,-1.664063 h -4.265625 v 14.589844 h 3.949219 c 1.505859,0 2.871094,-0.155273 4.089844,-0.46875 1.224609,-0.319336 2.273437,-0.796875 3.140625,-1.429687 0.873047,-0.632813 1.549804,-1.417969 2.027344,-2.355469 0.474609,-0.9375 0.714843,-2.009766 0.714843,-3.222656 z M 51.828095,7.765625e-4 V -51.69063 h 31.125 v 8.226563 H 61.71872 v 12.855469 h 20.25 v 8.027343 h -20.25 V -8.2257859 H 82.953095 V 7.765625e-4 Z m 0,0"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         aria-label="RE"
+         transform="matrix(1.3333333,0,0,1.3333333,54.579467,362.91693)" />
+      <path
+         id="path9"
+         d="M 0,0 0.041,0.057 Z"
+         style="fill:#f3782a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,121.9896,121.27373)" />
+      <path
+         id="path10"
+         d="m 126.54,299.219 -35.006,-90.824 47.759,65.45 18.516,25.374 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,399.50933)"
+         style="fill:url(#linearGradient10);stroke:none" />
+      <path
+         id="path11"
+         d="M 0,0 0.041,0.057 35.048,90.881 C 25.75,78.139 -79.131,-65.592 -91.492,-82.532 h 31.268 C -49.353,-67.634 -10.122,-13.872 0,0"
+         style="fill:#f37721;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,121.98947,121.17453)"
+         clip-path="url(#clipPath12)" />
+      <path
+         id="path13"
+         d="m 0,0 83.895,-62.085 h 42.55 z"
+         style="fill:#f37721;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,102.0956,148.43733)"
+         clip-path="url(#clipPath14)" />
+      <path
+         id="path15"
+         d="M 76.572,188.23 203.017,126.145 91.492,208.677 Z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,399.50933)"
+         style="fill:url(#linearGradient15);stroke:none" />
+      <path
+         id="path16"
+         d="m 0,0 -57.258,-78.467 0.031,-0.023 -7.482,-10.254 35.193,5.444 z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,226.95693,0.09853333)"
+         clip-path="url(#clipPath17)" />
+      <path
+         id="path18"
+         d="M 0,0 -35.193,-5.445 79.219,-90.113 h 42.717 C 105.567,-78.182 18.169,-13.436 0,0"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,187.60213,111.06587)"
+         clip-path="url(#clipPath19)" />
+      <path
+         id="path20"
+         d="m 237.877,144.343 25.197,-18.198 v 135.519 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,399.50933)"
+         style="fill:url(#linearGradient20);stroke:none" />
+      <path
+         id="path21"
+         d="m 0,0 h -73.98 v -0.043 l -0.015,0.011 -33.024,-44.976 34.921,5.341 10.769,14.667 h 36.349 v -92.658 z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,350.76547,50.624267)"
+         clip-path="url(#clipPath22)" />
+      <path
+         id="path23"
+         d="M 0,0 V 25 H -92.42 L -79.668,0 Z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,350.18373,33.883467)"
+         clip-path="url(#clipPath24)" />
+      <path
+         id="path25"
+         d="m 140.701,216.258 42.269,57.926 -12.752,25.374 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,399.50933)"
+         style="fill:url(#linearGradient25);stroke:none" />
+      <path
+         id="path26"
+         d="M 0,0 -18.088,13.386 0,-31.489 Z"
+         style="fill:#44c7f4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,279.41933,121.29107)"
+         clip-path="url(#clipPath27)" />
+      <path
+         id="path28"
+         d="m 156.314,216.628 53.312,-39.453 -18.088,44.875 z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,399.50933)"
+         style="fill:url(#linearGradient28);stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -61,20 +61,20 @@ const NAVIGATION: NavItem[] = [
     class="flex justify-between items-center py-1 px-5 max-w-7xl mb-8 justify-self-center w-full mx-auto bg-backgroundSecondary sm:rounded-xl sm:mx-5 sm:mt-2 sm:mb-8 sm:w-auto xl:mx-auto xl:w-full"
   >
     <nav class="w-full">
-      <div class="relative h-16 flex items-center justify-between">
+      <div class="relative h-20 flex items-center justify-between">
         <a href="/" class="sm:flex gap-x-4 items-center hidden">
           <img
-            src="/images/tglogo-bw.png"
+            src="/tg25/tg25_horizontal_white.svg"
             alt="The Gathering logo"
-            width={150}
+            width={170}
             class="aspect-thumbnail object-cover"
           />
         </a>
-        <a href="/" class="flex gap-x-4 items-center sm:hidden">
+        <a href="/" class="flex gap-x-4 -ml-1 items-center sm:hidden">
           <img
-            src="/images/tglogo-tg.png"
+            src="/tg25/tg25_horizontal_white.svg"
             alt="The Gathering logo"
-            width={75}
+            width={130}
             class="aspect-thumbnail object-cover"
           />
         </a>


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/117

**Do not merge, only switched out of draft state to get review url**

In order to make logo details comfortable enough I had to increase header size a bit. Think slimmer header looks a bit nicer, but not end of the world.

Did not change favicon, as I'm not quite sure icon is very TG recognisable. Example
<img width="1295" alt="Screenshot 2024-12-07 at 10 47 43" src="https://github.com/user-attachments/assets/2c9e462c-63f1-491b-b356-a64bcecaf3a0">

# Examples using current logo variants

Ended up using the horisontal logo variant for all cases, since
- It doesn't require any more height than the square variant (and provides more relevant info/context)
- It bears way more profile/theme context than standalone symbol

<img width="1397" alt="Screenshot 2024-12-07 at 10 39 21" src="https://github.com/user-attachments/assets/f22764e2-aed0-42fc-b4d1-912fdc5a092f">
<img width="327" alt="Screenshot 2024-12-07 at 10 40 00" src="https://github.com/user-attachments/assets/a140d2a1-8aa6-4dd2-a296-84e3000b152a">
<img width="640" alt="Screenshot 2024-12-07 at 10 40 15" src="https://github.com/user-attachments/assets/a396bd43-4d3e-4ea9-a61d-75ca464c4418">
