### PR TITLE
feat: always include duplicate top nav items

### DIFF
--- a/src/components/navigation/NavItem.astro
+++ b/src/components/navigation/NavItem.astro
@@ -30,7 +30,8 @@ const itemsWithParent: Array<
   NavItem & {
     touchOnly?: boolean;
   }
-> = path ? [{ path, title, touchOnly: true }, ...items] : items;
+  // Add copy of head item as top item in list, for people that don't like to click a hoverable item and mobile users where hover is not an option
+> = path ? [{ path, title: "Oversikt", touchOnly: false }, ...items] : items;
 ---
 
 <script>


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/133

Also changes name of top item to make it less of an echo from item itself, hopefully generic enough to work with any nav item.

<img width="305" alt="Screenshot 2025-02-10 at 23 59 31" src="https://github.com/user-attachments/assets/1244bf2f-4f14-40bb-a2e7-5945443316aa" />
<img width="183" alt="Screenshot 2025-02-10 at 23 59 49" src="https://github.com/user-attachments/assets/45771fdc-b39c-4f7b-bf5e-9cabf345c3fa" />
