### PR TITLE
feat: add json-ld to various pages

### DIFF
--- a/src/components/practical/PracticalPage.astro
+++ b/src/components/practical/PracticalPage.astro
@@ -18,7 +18,7 @@ const { title, faq = [], intro, body } = Astro.props;
     <div class="prose" set:html={body} />
   </section>
   {
-    faq.length > 0 ? (
+    !!faq.length ? (
       <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4 mt-8">
         <H2 text="Vanlige spørsmål" class="sm:col-span-2 lg:col-span-3" />
         {faq.map((item) => (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,6 +10,7 @@ interface Props {
   search_description?: string;
   introText?: string;
   type?: string;
+  jsonLd?: unknown;
 }
 
 const {
@@ -21,6 +22,7 @@ const {
   lang = "no",
   image = "https://www.tg.no/images/tg23-oversikt.jpg",
   description = "We have hosted The Gathering since 1992 and it has always been a hub for young creative people to battle it out in many types of competitions; demo-coding, music, graphics, animation, and gaming.",
+  jsonLd = undefined,
 } = Astro.props;
 
 const finalTitle = seo_title || title;
@@ -55,6 +57,16 @@ const matomoInstanceUrl =
     <meta property="twitter:card" content="summary_large_image" />
 
     <title>{title}</title>
+
+    {
+      jsonLd ? (
+        <script
+          is:inline
+          type="application/ld+json"
+          set:html={JSON.stringify(jsonLd)}
+        />
+      ) : null
+    }
 
     <!-- Matomo -->
     <script is:inline define:vars={{ matomoInstanceUrl, matomoSiteId }}>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -24,6 +24,20 @@ const article = await fetchArticleById({
   id,
   api_url: import.meta.env.API_URL,
 });
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  headline: `${article.title}`,
+  image: article.main_image?.sizes.large.url
+    ? [article.main_image?.sizes.large.url]
+    : [],
+  datePublished: article.meta.first_published_at,
+  author: article.contributors.map((contributor) => ({
+    "@type": "Person",
+    name: contributor.name,
+  })),
+};
 ---
 
 <Layout
@@ -35,6 +49,7 @@ const article = await fetchArticleById({
   type="article"
   lang=`${article.meta.locale || "no"}`
   image=`${article.main_image?.sizes.large.url}`
+  jsonLd={jsonLd}
 >
   <Main>
     <ContentContainer variant="wide">

--- a/src/pages/practical/[...path].astro
+++ b/src/pages/practical/[...path].astro
@@ -29,6 +29,21 @@ const page = await fetchInfoPageByPath({
 if (!page) {
   return Astro.rewrite("/404");
 }
+
+const jsonLd = !!page.faq?.length
+  ? {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: page.faq.map((item) => ({
+        "@type": "Question",
+        name: item.title,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.body,
+        },
+      })),
+    }
+  : undefined;
 ---
 
 <Layout
@@ -37,8 +52,8 @@ if (!page) {
   seo_title=`${page.meta.seo_title}`
   search_description=`${page.meta.search_description}`
   introText=`${page.intro}`
-  type="article"
   lang=`${page.meta.locale || "no"}`
+  jsonLd={jsonLd}
 >
   <Main>
     <PracticalPage {...page} />

--- a/src/pages/tickets/index.astro
+++ b/src/pages/tickets/index.astro
@@ -16,9 +16,38 @@ const boxStyles = [
 ];
 const buttonStyles =
   "block px-4 py-2 rounded-full content-center text-decoration-none text-center";
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Event",
+  name: "The Gathering 2025",
+  startDate: "2025-04-16",
+  endDate: "2025-04-20",
+  eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+  eventStatus: "https://schema.org/EventScheduled",
+  location: {
+    "@type": "Place",
+    name: "Vikingskipet",
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "Åkersvikvegen 1",
+      addressLocality: "Hamar",
+      postalCode: "2321",
+      addressRegion: "Innlandet",
+      addressCountry: "NO",
+    },
+  },
+  description:
+    "The Gathering er Norges største dataparty - Fem uforglemmelige dager i norges feteste påskehytte!",
+  organizer: {
+    "@type": "Organization",
+    name: "KANDU",
+    url: "https://www.kandu.no",
+  },
+};
 ---
 
-<Layout title="The Gathering - Billetter">
+<Layout title="The Gathering - Billetter" jsonLd={jsonLd}>
   <Main>
     <ContentContainer>
       <H1


### PR DESCRIPTION
Part of: https://github.com/gathering/tgno-frontend/issues/134

Adds json-ld data to a few different page types to hopefully make them easier to parse and present to search engines (google)