### PR TITLE
feat: style article meta data

### DIFF
--- a/src/components/ContentContainer.astro
+++ b/src/components/ContentContainer.astro
@@ -12,6 +12,6 @@ const { variant = "wide" } = Astro.props;
 const variantStyles = VARIANTS[variant] || VARIANTS.wide;
 ---
 
-<section class={`mb-4 ${variantStyles}`}>
+<section class={`mb-6 ${variantStyles}`}>
   <slot />
 </section>

--- a/src/components/frontpage/NewsComp.astro
+++ b/src/components/frontpage/NewsComp.astro
@@ -47,7 +47,7 @@ const gridStyles = singleColumn
                 class="text-sm text-gray-500"
               >
                 {new Date(article.meta.first_published_at).toLocaleDateString(
-                  "en-US",
+                  "nb-NO",
                   {
                     year: "numeric",
                     month: "long",

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -61,49 +61,69 @@ const jsonLd = {
               src={article.main_image.sizes.large.url}
               srcset={`${article.main_image.sizes.large.url} 500w, ${article.main_image.sizes.extra_large.url} 1000w`}
               alt={article.main_image.alt}
-              class="w-auto rounded-3xl mb-5 object-cover object-center"
+              class="w-auto rounded-3xl object-cover object-center"
             />
           </div>
         )
       }
     </ContentContainer>
     <ContentContainer variant="narrow">
-      <aside class="mb-5">
-        <p class="text-sm text-gray-600 mb-2">
-          {
-            article.tags
-              .filter((tag) => tag.name !== "NotNews") // Filter out the "NotNews" tag
-              .map((tag) => {
-                return tag.name
-                  .split(" ")
-                  .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-                  .join(" ");
-              })
-              .join(", ")
-          }
-        </p>
-        <time
-          datetime={article.meta.first_published_at}
-          class="text-sm text-gray-500 mb-2 block"
-        >
-          {new Date(article.meta.first_published_at).toLocaleDateString()}
-        </time>
-        <table class="">
-          <tbody class="text-sm text-gray-500 mb-2 block">
-            {
-              article.contributors.map((contributor) => (
-                <tr>
-                  <td class="">{contributor.contribution_type}</td>
-                  <td class="">| {contributor.name}</td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
-      </aside>
       <!-- Article Content -->
       <Intro text={article.intro} />
-      <div class="prose" set:html={article.body} />
+      <div class="prose mb-6" set:html={article.body} />
+      <aside
+        class="mb-6 p-5 space-y-5 text-sm text-white/70 bg-white/5 rounded"
+      >
+        <section class="space-y-1">
+          <time
+            datetime={article.meta.first_published_at}
+            class="text-sm text-white"
+          >
+            Publisert:{" "}
+            {
+              new Date(article.meta.first_published_at).toLocaleDateString(
+                "nb-NO",
+                {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                },
+              )
+            }
+          </time>
+          {
+            !!article.tags.length ? (
+              <p class="text-sm mb-1">
+                {article.tags
+                  .filter((tag) => tag.name !== "NotNews") // Filter out the "NotNews" tag
+                  .map((tag) => {
+                    return tag.name
+                      .split(" ")
+                      .map(
+                        (word) => word.charAt(0).toUpperCase() + word.slice(1),
+                      )
+                      .join(" ");
+                  })
+                  .join(", ")}
+              </p>
+            ) : null
+          }
+        </section>
+        {
+          !!article.contributors.length ? (
+            <section>
+              <div class="flex flex-row flex-wrap text-sm">
+                {article.contributors.map((contributor) => (
+                  <dl class="flex flex-col mb-2 mr-4">
+                    <dt class="font-bold text-white">{contributor.name}</dt>
+                    <dd class="">{contributor.contribution_type}</dd>
+                  </dl>
+                ))}
+              </div>
+            </section>
+          ) : null
+        }
+      </aside>
     </ContentContainer>
   </Main>
 </Layout>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -4,7 +4,11 @@ import Intro from "../../components/Intro.astro";
 import Main from "../../components/Main.astro";
 import ContentContainer from "../../components/ContentContainer.astro";
 import Layout from "../../layouts/Layout.astro";
-import { fetchArticleIdBySlug, fetchArticleById } from "../../utils";
+import {
+  fetchArticleIdBySlug,
+  fetchArticleById,
+  noLocalizeContributor,
+} from "../../utils";
 
 const { slug } = Astro.params;
 
@@ -95,7 +99,6 @@ const jsonLd = {
             !!article.tags.length ? (
               <p class="text-sm mb-1">
                 {article.tags
-                  .filter((tag) => tag.name !== "NotNews") // Filter out the "NotNews" tag
                   .map((tag) => {
                     return tag.name
                       .split(" ")
@@ -113,12 +116,16 @@ const jsonLd = {
           !!article.contributors.length ? (
             <section>
               <div class="flex flex-row flex-wrap text-sm -mb-2">
-                {article.contributors.map((contributor) => (
-                  <dl class="flex flex-col mb-2 mr-4">
-                    <dt class="font-bold text-white/90">{contributor.name}</dt>
-                    <dd class="">{contributor.contribution_type}</dd>
-                  </dl>
-                ))}
+                {article.contributors
+                  .map(noLocalizeContributor)
+                  .map((contributor) => (
+                    <dl class="flex flex-col mb-2 mr-4">
+                      <dt class="font-bold text-white/90">
+                        {contributor.name}
+                      </dt>
+                      <dd class="">{contributor.contribution_type}</dd>
+                    </dl>
+                  ))}
               </div>
             </section>
           ) : null

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -72,12 +72,12 @@ const jsonLd = {
       <Intro text={article.intro} />
       <div class="prose mb-6" set:html={article.body} />
       <aside
-        class="mb-6 p-5 space-y-5 text-sm text-white/70 bg-white/5 rounded"
+        class="mb-6 p-5 space-y-5 text-sm text-white/60 bg-backgroundSecondary rounded"
       >
         <section class="space-y-1">
           <time
             datetime={article.meta.first_published_at}
-            class="text-sm text-white"
+            class="text-sm text-white/90"
           >
             Publisert:{" "}
             {
@@ -112,10 +112,10 @@ const jsonLd = {
         {
           !!article.contributors.length ? (
             <section>
-              <div class="flex flex-row flex-wrap text-sm">
+              <div class="flex flex-row flex-wrap text-sm -mb-2">
                 {article.contributors.map((contributor) => (
                   <dl class="flex flex-col mb-2 mr-4">
-                    <dt class="font-bold text-white">{contributor.name}</dt>
+                    <dt class="font-bold text-white/90">{contributor.name}</dt>
                     <dd class="">{contributor.contribution_type}</dd>
                   </dl>
                 ))}

--- a/src/types/articles.ts
+++ b/src/types/articles.ts
@@ -1,6 +1,13 @@
 import type { Image } from "./images";
 import type { MinimalApiPage, PaginatedResponse } from "./utils";
 
+export interface Contributor {
+  id: number;
+  name: string;
+  contribution_type: string;
+  image?: string;
+}
+
 export interface Article extends MinimalApiPage {
   id: number;
   meta: {
@@ -16,12 +23,7 @@ export interface Article extends MinimalApiPage {
   title: string;
   intro: string;
   body: string;
-  contributors: Array<{
-    id: number;
-    name: string;
-    contribution_type: string;
-    image?: string;
-  }>;
+  contributors: Contributor[];
   tags: Array<{
     id: number;
     name: string;

--- a/src/utils/articles.ts
+++ b/src/utils/articles.ts
@@ -58,6 +58,7 @@ export const fetchArticleById = async ({
 const I18N: Record<string, Record<string, string>> = {
   no: {
     photography: "Fotografi",
+    photo: "Foto",
     text: "Tekst",
     video: "Video",
     audio: "Audio",

--- a/src/utils/articles.ts
+++ b/src/utils/articles.ts
@@ -1,5 +1,6 @@
 import type {
   Article,
+  Contributor,
   FetchArticlesProps,
   FetchArticlesResponse,
 } from "../types";
@@ -53,3 +54,29 @@ export const fetchArticleById = async ({
   const data = await response.json();
   return data;
 };
+
+const I18N: Record<string, Record<string, string>> = {
+  no: {
+    photography: "Fotografi",
+    text: "Tekst",
+    video: "Video",
+    audio: "Audio",
+    illustration: "Illustrasjon",
+    animation: "Animasjon",
+    code: "Kode",
+    design: "Design",
+  },
+};
+
+export const localizeContributor = (
+  contributor: Contributor,
+  targetLocale = "no",
+): Contributor => ({
+  ...contributor,
+  contribution_type:
+    I18N[targetLocale]?.[contributor.contribution_type.toLowerCase()] ||
+    contributor.contribution_type,
+});
+
+export const noLocalizeContributor = (contributor: Contributor) =>
+  localizeContributor(contributor, "no");


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/59

Adds some nice styling, and moves meta data after main article contents. I think this aligns with how we use bylines and publish date; important to have available (both for us, contributors and readers), but generally not supposed to be read.

Desktop
<img width="748" alt="Screenshot 2025-02-18 at 21 03 58" src="https://github.com/user-attachments/assets/76c45052-41d8-4980-8802-45add5ba77df" />
Mobile
<img width="312" alt="Screenshot 2025-02-18 at 21 04 31" src="https://github.com/user-attachments/assets/7e6e5eaf-7ea6-4dd2-8a24-2f09c0124e0c" />

Before
<img width="732" alt="Screenshot 2025-02-18 at 20 57 44" src="https://github.com/user-attachments/assets/b7ad9e33-feae-4d33-b21a-095e807c9bf3" />
