### PR TITLE
feat: support uncroppable article images

### DIFF
--- a/src/components/H1.astro
+++ b/src/components/H1.astro
@@ -6,4 +6,6 @@ type Props = {
 const { text, color = "text-white" } = Astro.props;
 ---
 
-<h1 class=`text-2xl sm:text-6xl ${color} font-bold mb-8`>{text}</h1>
+<h1 class={`text-2xl sm:text-6xl ${color} font-bold mb-8 text-balance`}>
+  {text}
+</h1>

--- a/src/components/NewsComp.astro
+++ b/src/components/NewsComp.astro
@@ -20,7 +20,9 @@ const { articles } = Astro.props;
                 })
                 .join(", ")}
             </div>
-            <h3 class="text-xl text-white font-bold mt-2">{title}</h3>
+            <h3 class="text-xl text-white font-bold mt-2 text-pretty">
+              {title}
+            </h3>
             <time
               datetime={meta.first_published_at}
               class="text-sm text-gray-500"

--- a/src/components/NewsComp.astro
+++ b/src/components/NewsComp.astro
@@ -1,5 +1,6 @@
 ---
 import type { Article } from "../types";
+import TeaserImage from "./news/TeaserImage.astro";
 
 type Props = { articles: Article[] };
 
@@ -8,39 +9,30 @@ const { articles } = Astro.props;
 
 <div class="grid grid-cols-1 sm:grid-cols-2 gap-y-4 gap-x-5 lg:px-28 mb-10">
   {
-    articles.map((article) => (
-      <a href={`/news/${article.meta.slug}`}>
+    articles.map(({ title, meta, main_image, tags = [] }) => (
+      <a href={`/news/${meta.slug}`}>
         <article class="overflow-hidden flex flex-row p-4">
           <div class="flex-1">
             <div class="text-sm text-orange-500">
-              {article.tags
+              {tags
                 .map((tag) => {
                   return tag.name.charAt(0).toUpperCase() + tag.name.slice(1);
                 })
                 .join(", ")}
             </div>
-            <h3 class="text-xl text-white font-bold mt-2">{article.title}</h3>
+            <h3 class="text-xl text-white font-bold mt-2">{title}</h3>
             <time
-              datetime={article.meta.first_published_at}
+              datetime={meta.first_published_at}
               class="text-sm text-gray-500"
             >
-              {new Date(article.meta.first_published_at).toLocaleDateString(
-                "en-US",
-                {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                },
-              )}
+              {new Date(meta.first_published_at).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
             </time>
           </div>
-          {article.main_image && (
-            <img
-              src={article.main_image.sizes.thumbnail.url}
-              alt={article.main_image.alt}
-              class="w-24 h-24 object-cover ml-4 rounded-lg"
-            />
-          )}
+          <TeaserImage image={main_image} />
         </article>
       </a>
     ))

--- a/src/components/frontpage/NewsComp.astro
+++ b/src/components/frontpage/NewsComp.astro
@@ -2,6 +2,7 @@
 import type { FetchArticlesProps } from "../../types";
 import { fetchArticles } from "../../utils";
 import Button from "../Button.astro";
+import TeaserImage from "../news/TeaserImage.astro";
 
 type Props = {
   singleColumn?: boolean;
@@ -56,13 +57,7 @@ const gridStyles = singleColumn
                 )}
               </time>
             </div>
-            {article.main_image && (
-              <img
-                src={article.main_image.sizes.thumbnail.url}
-                alt={article.main_image.alt}
-                class="w-24 h-24 object-cover ml-4 rounded-lg"
-              />
-            )}
+            <TeaserImage image={article.main_image} />
           </article>
         </a>
       ))

--- a/src/components/frontpage/NewsComp.astro
+++ b/src/components/frontpage/NewsComp.astro
@@ -42,7 +42,9 @@ const gridStyles = singleColumn
                   })
                   .join(", ")}
               </div>
-              <h3 class="text-xl text-white font-bold mt-2">{article.title}</h3>
+              <h3 class="text-xl text-white font-bold mt-2 text-pretty">
+                {article.title}
+              </h3>
               <time
                 datetime={article.meta.first_published_at}
                 class="text-sm text-gray-500"

--- a/src/components/news/TeaserImage.astro
+++ b/src/components/news/TeaserImage.astro
@@ -1,0 +1,19 @@
+---
+import type { Article } from "../../types";
+
+type Props = { image?: Article["main_image"] };
+
+const { image } = Astro.props;
+
+if (!image) {
+  return null;
+}
+
+const { uncroppable = false, sizes, alt } = image;
+---
+
+<img
+  src={uncroppable ? sizes.small.url : sizes.thumbnail.url}
+  alt={alt}
+  class={`w-24 h-24 ${uncroppable ? "object-contain bg-white/5" : "object-cover"} ml-4 rounded-lg`}
+/>

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -56,16 +56,21 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <Main>
-    <ContentContainer variant="wide">
-      <H1 text=`${article.title}` />
+    <ContentContainer
+      variant={article.main_image?.uncroppable ? "narrow" : "wide"}
+    >
+      <H1 text={article.title} />
       {
         article.main_image && (
           <div class="flex md:max-h-[50vh]">
             <img
               src={article.main_image.sizes.large.url}
-              srcset={`${article.main_image.sizes.large.url} 500w, ${article.main_image.sizes.extra_large.url} 1000w`}
+              srcset={Object.values(article.main_image.sizes)
+                .sort((a, b) => a.width - b.width)
+                .map((size) => `${size.url} ${size.width}w`)
+                .join(", ")}
               alt={article.main_image.alt}
-              class="w-auto rounded-3xl object-cover object-center"
+              class="w-auto rounded-3xl md:object-cover object-center"
             />
           </div>
         )

--- a/src/types/images.ts
+++ b/src/types/images.ts
@@ -8,6 +8,7 @@ export interface Image {
   title: string;
   alt: string;
   url: string;
+  uncroppable?: boolean;
   sizes: {
     thumbnail: ImageSize;
     small: ImageSize;


### PR DESCRIPTION
Another one directly from slack PMs (sorry 😞). This will require some backend changes as well, but felt safest to experiment a bit with frontend behaviour first. This should be backwards compatible and safe to deploy without backend changes.

If a main article image is marked as "uncroppable" in backend then frontend will do whatever it can to make sure entire image is always visible, and do minor layout adjustments to compensate.
* In teasers we put image inside thumbnail frame, add semi-discreet background, and select a (most likely) uncropped image url/size
* In article we put image inside image frame, and adjust entire header width to align with main text body to avoid any wide/square image from becoming incredibly high on desktop (due to image frame usually being the "full" window width)

As a little bonus we add some CSS rules on how the corresponding article heading should break lines to make everything look a bit nicer.

## Regular behaviour
<img width="1063" alt="Screenshot 2025-02-19 at 18 43 28" src="https://github.com/user-attachments/assets/ff757024-4360-4f4b-85d3-0daf5b2d593b" />

## Uncroppable image
<img width="1059" alt="Screenshot 2025-02-19 at 18 44 01" src="https://github.com/user-attachments/assets/f5d081d4-4492-44fb-b23b-7239104228e7" />

## Bad line break
<img width="1170" alt="Screenshot 2025-02-19 at 18 42 32" src="https://github.com/user-attachments/assets/39aa7778-508d-456c-a7e3-00bc247a2b39" />

## Nicer line break
<img width="1167" alt="Screenshot 2025-02-19 at 18 42 22" src="https://github.com/user-attachments/assets/895bf1ef-6290-4553-aca7-62851ca27d24" />