### PR TITLE
fix: add missing consent form links

### DIFF
--- a/src/pages/event/rules.astro
+++ b/src/pages/event/rules.astro
@@ -198,15 +198,15 @@ const sectionStyles = [
           <p>
             Deltakere som ikke har fylt 16 år innen de ankommer The Gathering må
             ha samtykke fra foresatte for å delta på The Gathering. Dette
-            samtykket leveres i form av et signert samtykkeskjema som lastes opp
-            på GeekEvents eller tas med i fysisk form. Deltakere under 16 år som
-            ikke har foresattes samtykke vil avvises ved innsjekk.
+            samtykket leveres i form av et signert <a
+              href="/practical/consent-form">samtykkeskjema</a
+            > som lastes opp på GeekEvents eller tas med i fysisk form. Deltakere
+            under 16 år som ikke har foresattes samtykke vil avvises ved innsjekk.
           </p>
           <p>
-            Samtykkeskjema finner du ved å klikke her (kommer snart, <a
-              href="/contact"
-              >Dersom du har spørsmål ta kontakt via kontaktskjemaet vårt</a
-            >).
+            <a href="/practical/consent-form"
+              >Samtykkeskjema finner du ved å klikke her</a
+            >
           </p>
 
           <h3>3. Vær årvåken og ta vare på hverandre</h3>

--- a/src/pages/tickets/terms-and-conditions.astro
+++ b/src/pages/tickets/terms-and-conditions.astro
@@ -65,8 +65,9 @@ const sectionStyles = [
             </li>
             <li>
               Deltakere under 16 år må ha foreldre eller foresattes samtykke.
-              Dette skal dokumenteres via et samtykkeskjema som må fylles ut og
-              sendes inn før deltakelse.
+              Dette skal dokumenteres via et <a href="/practical/consent-form"
+                >samtykkeskjema</a
+              > som må fylles ut og sendes inn før deltakelse.
             </li>
             <li>Gyldig ID må kunne fremvises ved ankomst.</li>
           </ul>


### PR DESCRIPTION
Requested via slack, should be self explanatory. Linking to main consent form page instead of pdf, since we expect different pdf per year