### PR TITLE
fix: respect default backend article ordering

### DIFF
--- a/src/types/articles.ts
+++ b/src/types/articles.ts
@@ -16,6 +16,7 @@ export interface Article extends MinimalApiPage {
     html_url: string;
     slug: string;
     first_published_at: string;
+    custom_published_at: string | null;
     seo_title: string;
     search_description: string;
     locale?: "en" | "no";

--- a/src/utils/articles.ts
+++ b/src/utils/articles.ts
@@ -13,10 +13,12 @@ export const fetchArticles = async ({
   offset = 0,
 }: FetchArticlesProps) => {
   const url = new URL(`${api_url}api/v2/news/`);
-  url.searchParams.set("fields", "title,tags,first_published_at,main_image");
+  url.searchParams.set(
+    "fields",
+    "title,tags,first_published_at,custom_published_at,main_image",
+  );
   url.searchParams.set("limit", limit.toString(10));
   url.searchParams.set("offset", offset.toString(10));
-  url.searchParams.set("order", "-first_published_at");
 
   if (tags?.length) {
     url.searchParams.set("tags", tags.join(","));


### PR DESCRIPTION
Blocked by: https://github.com/gathering/tgno-backend/pull/42
Part of: https://github.com/gathering/tgno-backend/issues/31

Once backend changes have been merged this should remove frontend custom sorting and instead rely on API defaults (which was previously "wrong").