### PR TITLE
feat: add explicit TZ env in example and runtime files

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,3 +6,4 @@ API_URL="https://dev.tg.no/"
 
 # MATOMO_SITE_ID=2
 # MATOMO_INSTANCE_URL="//matomo.gathering.org/"
+TZ=Europe/Oslo

--- a/.env.runtime
+++ b/.env.runtime
@@ -4,3 +4,4 @@ API_URL=placeholder
 SITE_URL=placeholder
 MATOMO_SITE_ID=placeholder
 MATOMO_INSTANCE_URL=placeholder
+TZ=placeholder

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,4 +5,5 @@ interface ImportMetaEnv {
   readonly SITE_URL: string;
   readonly MATOMO_SITE_ID: string;
   readonly MATOMO_INSTANCE_URL: string;
+  readonly TZ: string;
 }


### PR DESCRIPTION
Node is still not super happy picking these up during runtime, but thing this (combined with adding them to production env) should work as expected.

If not we need to either
* Pass env to node a bit more agressively (ex. `process.env.TZ = import.meta.env.TZ` in key places)
* Change to more robust datetime library that allows us to explicitly use TZ in all relevant methods