### PR TITLE
feat: filter out events that started outside range

### DIFF
--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -51,11 +51,13 @@ const tagsFilter = (Astro.url.searchParams.get("tags") || "")
   .split(",")
   .filter(Boolean);
 
-const events = await fetchEvents({
-  ...dateFilter,
-  tags: tagsFilter,
-  api_url: import.meta.env.API_URL,
-});
+const events = (
+  await fetchEvents({
+    ...dateFilter,
+    tags: tagsFilter,
+    api_url: import.meta.env.API_URL,
+  })
+).filter((event) => ["none", "end"].includes(event.facts.extendingQuery));
 ---
 
 <script>


### PR DESCRIPTION
When looking at a specific day of events there can/will be events that started the day before and overlap with a few hours. There are several ways to handles this (why we have different event styles, etc). For now we will just hide said events to make it easier to parse (even if it becomes slightly less informative/correct)

Option A - View it as "normal" (but note additional info on duration)
<img width="351" alt="Screenshot 2025-03-08 at 19 28 47" src="https://github.com/user-attachments/assets/891f4976-268e-4000-a361-5b981b202979" />

Option B - Show it in a more descrete variant (I think this is what we ideally want long term, if we can find a good design for it)
<img width="352" alt="Screenshot 2025-03-08 at 19 29 09" src="https://github.com/user-attachments/assets/f2da13ae-9307-4135-9846-0958780e21f3" />

Option C - Don't show it at all
<img width="351" alt="Screenshot 2025-03-08 at 19 32 44" src="https://github.com/user-attachments/assets/f4cc1dfb-3b1a-45d4-9fd2-cacf16a730be" />

For now we went with option C. But events are available to frontend, so can be tweaked as needed without backend changes
