### PR TITLE
chore: remove unused client side event sorting

### DIFF
--- a/src/components/schedule/Event.astro
+++ b/src/components/schedule/Event.astro
@@ -66,7 +66,7 @@ let DurationSymbol = ClockSymbol;
 
 switch (facts.extendingQuery) {
   case "start":
-    duration = `${strings.startDate} ${strings.startDate} - ${strings.endTime}`;
+    duration = `${strings.startDate} ${strings.startTime} - ${strings.endTime}`;
     DurationSymbol = CalendardSymbol;
     break;
   case "end":

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -31,65 +31,60 @@ export const fetchEvents = async ({
   const data = await response.json();
   const pad = (number: number) => String(number).padStart(2, "0");
 
-  return (
-    data
-      // TODO: Remove once backend sorts correct by default
-      .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
-      .map((event) => {
-        const startObj = new Date(event.start);
-        const endObj = new Date(event.end);
-        const reqStartObj = reqStart ? new Date(reqStart) : null;
-        const reqEndObj = reqEnd ? new Date(reqEnd) : null;
+  return data.map((event) => {
+    const startObj = new Date(event.start);
+    const endObj = new Date(event.end);
+    const reqStartObj = reqStart ? new Date(reqStart) : null;
+    const reqEndObj = reqEnd ? new Date(reqEnd) : null;
 
-        const newEvent: Event = {
-          ...event,
-          tags: event.tags
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .sort((a, b) => TAG_TYPE_PRIO[a.type] - TAG_TYPE_PRIO[b.type])
-            .map((tag) => ({
-              ...tag,
-              secondary: tag.type !== "location",
-              hidden: tag.slug === "meta",
-            })),
-          facts: {
-            immediate: event.start === event.end,
-            sameDay: startObj.getDate() === endObj.getDate(),
-            ended: Date.now() > endObj.getTime(),
-            extendingQuery: "none",
-          },
-          strings: {
-            startTime: `${pad(startObj.getHours())}:${pad(startObj.getMinutes())}`,
-            endTime: `${pad(endObj.getHours())}:${pad(endObj.getMinutes())}`,
-            startDate: startObj.toLocaleDateString("no-NO", {
-              day: "numeric",
-              weekday: "long",
-            }),
-            endDate: endObj.toLocaleDateString("no-NO", {
-              day: "numeric",
-              weekday: "long",
-            }),
-            duration: `${pad(startObj.getHours())}:${pad(startObj.getMinutes())} - ${pad(endObj.getHours())}:${pad(endObj.getMinutes())}`,
-          },
-        };
+    const newEvent: Event = {
+      ...event,
+      tags: event.tags
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .sort((a, b) => TAG_TYPE_PRIO[a.type] - TAG_TYPE_PRIO[b.type])
+        .map((tag) => ({
+          ...tag,
+          secondary: tag.type !== "location",
+          hidden: tag.slug === "meta",
+        })),
+      facts: {
+        immediate: event.start === event.end,
+        sameDay: startObj.getDate() === endObj.getDate(),
+        ended: Date.now() > endObj.getTime(),
+        extendingQuery: "none",
+      },
+      strings: {
+        startTime: `${pad(startObj.getHours())}:${pad(startObj.getMinutes())}`,
+        endTime: `${pad(endObj.getHours())}:${pad(endObj.getMinutes())}`,
+        startDate: startObj.toLocaleDateString("no-NO", {
+          day: "numeric",
+          weekday: "long",
+        }),
+        endDate: endObj.toLocaleDateString("no-NO", {
+          day: "numeric",
+          weekday: "long",
+        }),
+        duration: `${pad(startObj.getHours())}:${pad(startObj.getMinutes())} - ${pad(endObj.getHours())}:${pad(endObj.getMinutes())}`,
+      },
+    };
 
-        if (newEvent.facts.immediate) {
-          newEvent.strings.duration = `${newEvent.strings.startTime}`;
+    if (newEvent.facts.immediate) {
+      newEvent.strings.duration = `${newEvent.strings.startTime}`;
+    }
+
+    if (reqStartObj && reqEndObj) {
+      if (endObj.getTime() > reqEndObj.getTime()) {
+        newEvent.facts.extendingQuery = "end";
+      }
+      if (startObj.getTime() < reqStartObj.getTime()) {
+        if (newEvent.facts.extendingQuery === "end") {
+          newEvent.facts.extendingQuery = "both";
+        } else {
+          newEvent.facts.extendingQuery = "start";
         }
+      }
+    }
 
-        if (reqStartObj && reqEndObj) {
-          if (endObj.getTime() > reqEndObj.getTime()) {
-            newEvent.facts.extendingQuery = "end";
-          }
-          if (startObj.getTime() < reqStartObj.getTime()) {
-            if (newEvent.facts.extendingQuery === "end") {
-              newEvent.facts.extendingQuery = "both";
-            } else {
-              newEvent.facts.extendingQuery = "start";
-            }
-          }
-        }
-
-        return newEvent;
-      })
-  );
+    return newEvent;
+  });
 };


### PR DESCRIPTION
With https://github.com/gathering/tgno-backend/pull/46/files#diff-6f6a60ed2af6e4824039d2489ce354836618088d2433ffcbde255b70da0104adR67 in place we should hopefully not need this anymore

(Diff is a bit confusing, but only sorting on line 37 was removed)