### PR TITLE
feat: show 2 hours into next day when filtering calendar

### DIFF
--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -20,7 +20,7 @@ const CONFIG = {
     ...[16, 17, 18, 19, 20].map((date) => {
       // TODO: Adjust timezone to +1 when filtering for dates outside of summer time
       const start = `2025-04-${date} 00:00+02:00`;
-      const end = `2025-04-${date + 1} 00:00+02:00`;
+      const end = `2025-04-${date + 1} 02:00+02:00`;
       return {
         slug: `2025-04-${date}`,
         label: new Date(start).toLocaleDateString("no-NO", {


### PR DESCRIPTION
When looking at a specific date in calendar we only show events that start on that specific day. It was raised that we also have a couple of events starting right after midnight that it would probably be nice for users to see when looking at the day before.

For example this is what it looks like today
<img width="864" alt="Screenshot 2025-03-11 at 21 36 38" src="https://github.com/user-attachments/assets/b7f7ddef-498a-41b0-b6ab-dbe57eccadea" />

And this is what it would looks like if we also including the next few hours of the next day
<img width="838" alt="Screenshot 2025-03-11 at 21 36 47" src="https://github.com/user-attachments/assets/c77cf76c-21c8-45ec-bfa6-7a458ae323ab" />