### PR TITLE
fix: remove use of png images

### DIFF
--- a/src/pages/about/expo.astro
+++ b/src/pages/about/expo.astro
@@ -20,8 +20,8 @@ const buttonStyles =
       <div class="grid grid-cols-1 sm:grid-cols-7 gap-x-4 gap-y-4">
         <aside class={`${boxStyles} sm:col-span-3 min-h-64`}>
           <img
-            src="https://www.tg.no/media/images/TG-artikler.max-1600x1600.png"
-            srcset="https://www.tg.no/media/images/TG-artikler.max-1600x1600.png 500w, https://www.tg.no/media/images/TG-artikler.max-3200x3200.png 1000w"
+            src="https://www.tg.no/media/images/TG-artikler.original.max-1600x1600.jpg"
+            srcset="https://www.tg.no/media/images/TG-artikler.original.max-1600x1600.jpg 500w, https://www.tg.no/media/images/TG-artikler.original.max-3200x3200.jpg 1000w"
             alt='Bilde av "Community village" fra TG 23, prototypen på Expo-området vårt'
             class="w-full h-full object-cover rounded-3xl"
           />

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -19,8 +19,8 @@ const buttonStyles =
           class={`${boxStyles} sm:col-span-4 min-h-64 sm:min-h-auto sm:max-h-64`}
         >
           <img
-            src="https://www.tg.no/media/images/TG-artikler.max-1600x1600.png"
-            srcset="https://www.tg.no/media/images/TG-artikler.max-1600x1600.png 500w, https://www.tg.no/media/images/TG-artikler.max-3200x3200.png 1000w"
+            src="https://www.tg.no/media/images/TG-artikler.original.max-1600x1600.jpg"
+            srcset="https://www.tg.no/media/images/TG-artikler.original.max-1600x1600.jpg 500w, https://www.tg.no/media/images/TG-artikler.original.max-3200x3200.jpg 1000w"
             alt='Bilde av "Community village" fra TG 23, prototypen på Expo-området vårt'
             class="w-full h-full object-cover rounded-3xl"
           />

--- a/src/pages/about/sponsor.astro
+++ b/src/pages/about/sponsor.astro
@@ -20,8 +20,8 @@ const buttonStyles =
       <div class="grid grid-cols-1 sm:grid-cols-7 gap-x-4 gap-y-4">
         <aside class={`${boxStyles} sm:col-span-3 min-h-64`}>
           <img
-            src="https://www.tg.no/media/images/TG-artikler.max-1600x1600.png"
-            srcset="https://www.tg.no/media/images/TG-artikler.max-1600x1600.png 500w, https://www.tg.no/media/images/TG-artikler.max-3200x3200.png 1000w"
+            src="https://www.tg.no/media/images/TG-artikler.original.max-1600x1600.jpg"
+            srcset="https://www.tg.no/media/images/TG-artikler.original.max-1600x1600.jpg 500w, https://www.tg.no/media/images/TG-artikler.original.max-3200x3200.jpg 1000w"
             alt='Bilde av "Community village" fra TG 23, prototypen på Expo-området vårt'
             class="w-full h-full object-cover rounded-3xl"
           />


### PR DESCRIPTION
Reported via slack. We could in theory also change to a smarter image component, but also that would probably have some challenges when it comes to optimising png images. So replacing image here and in the related tg.no article.