### PR TITLE
feat: populate practical nav item with backend pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -55,10 +55,12 @@ const getNavigationItems: () => Promise<NavItem[]> = async () => {
     items
       .find((item) => item.title === "Praktisk")
       ?.items?.unshift(
-        ...practicalPage.pages.map(({ title, url }) => ({
-          title,
-          path: url,
-        })),
+        ...practicalPage.pages
+          .filter(({ show_in_menu }) => !!show_in_menu)
+          .map(({ title, url }) => ({
+            title,
+            path: url,
+          })),
       );
   }
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -56,7 +56,7 @@ const getNavigationItems: () => Promise<NavItem[]> = async () => {
       .find((item) => item.title === "Praktisk")
       ?.items?.unshift(
         ...practicalPage.pages
-          .filter(({ show_in_menu }) => !!show_in_menu)
+          .filter(({ show_in_menus }) => !!show_in_menus)
           .map(({ title, url }) => ({
             title,
             path: url,

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,53 +1,71 @@
 ---
 import type { NavItem } from "../types";
+import { fetchInfoPageByPath } from "../utils";
 import HeaderNavigation from "./HeaderNavigation.astro";
 
-const NAVIGATION: NavItem[] = [
-  {
-    title: "Aktuelt",
-    path: "/news",
-  },
-  {
-    title: "Program",
-    path: "/schedule",
-  },
-  {
-    title: "Om TG",
-    path: "/about",
-    items: [
-      { title: "Bli utstiller", path: "/about/expo" },
-      { title: "Bli sponsor", path: "/about/sponsor" },
-    ],
-  },
-  {
-    title: "Praktisk",
+const getNavigationItems: () => Promise<NavItem[]> = async () => {
+  const items = [
+    {
+      title: "Aktuelt",
+      path: "/news",
+    },
+    {
+      title: "Program",
+      path: "/schedule",
+    },
+    {
+      title: "Om TG",
+      path: "/about",
+      items: [
+        { title: "Bli utstiller", path: "/about/expo" },
+        { title: "Bli sponsor", path: "/about/sponsor" },
+      ],
+    },
+    {
+      title: "Praktisk",
+      path: "/practical",
+      items: [{ title: "Arrangementsregler", path: "/event/rules" }],
+    },
+    {
+      title: "Billetter",
+      path: "/tickets",
+      items: [
+        { title: "Vilkår", path: "/tickets/terms-and-conditions" },
+        { title: "Arrangementsregler", path: "/event/rules" },
+        { title: "Konstruksjonsregler", path: "/event/construction-rules" },
+      ],
+    },
+    {
+      title: "Konkurranser",
+      items: [
+        { title: "Kreative", path: "/competitions/creative" },
+        { title: "Esport", path: "/competitions/esport" },
+      ],
+    },
+    { title: "Kontakt oss", path: "/contact" },
+  ];
+
+  // This works for a couple of cases, but if we want more items we should probably optimise backend API for navigation generation purposes. And/or use a more advanced frontend caching strategy.
+  const practicalPage = await fetchInfoPageByPath({
     path: "/practical",
-    items: [
-      { title: "Pakkeliste", path: "/practical/packing-list" },
-      { title: "Sikkerhet", path: "/practical/brev-fra-sikkerhetsansvarlig" },
-      { title: "Samtykkeskjema", path: "/practical/consent-form" },
-      { title: "Arrangementsregler", path: "/event/rules" },
-      { title: "Konstruksjonsregler", path: "/event/construction-rules" },
-    ],
-  },
-  {
-    title: "Billetter",
-    path: "/tickets",
-    items: [
-      { title: "Vilkår", path: "/tickets/terms-and-conditions" },
-      { title: "Arrangementsregler", path: "/event/rules" },
-      { title: "Konstruksjonsregler", path: "/event/construction-rules" },
-    ],
-  },
-  {
-    title: "Konkurranser",
-    items: [
-      { title: "Kreative", path: "/competitions/creative" },
-      { title: "Esport", path: "/competitions/esport" },
-    ],
-  },
-  { title: "Kontakt oss", path: "/contact" },
-];
+    apiUrl: import.meta.env.API_URL,
+  });
+
+  if (practicalPage?.pages) {
+    items
+      .find((item) => item.title === "Praktisk")
+      ?.items?.unshift(
+        ...practicalPage.pages.map(({ title, url }) => ({
+          title,
+          path: url,
+        })),
+      );
+  }
+
+  return items;
+};
+
+const navigationItems = await getNavigationItems();
 ---
 
 <script>
@@ -99,7 +117,7 @@ const NAVIGATION: NavItem[] = [
         </a>
 
         <HeaderNavigation
-          navigationItems={NAVIGATION}
+          navigationItems={navigationItems}
           class="hidden sm:flex w-full space-x-6 space-y-0 justify-end"
           prioritized
         />
@@ -147,7 +165,7 @@ const NAVIGATION: NavItem[] = [
       <!-- Mobile menu, show/hide based on menu state. -->
       <div class="hidden" id="mobile-menu" data-part="mobile-menu">
         <HeaderNavigation
-          navigationItems={NAVIGATION}
+          navigationItems={navigationItems}
           class="space-y-3 px-2 pb-3 pt-2 flex flex-col"
           hamburger
         />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,7 +24,10 @@ const getNavigationItems: () => Promise<NavItem[]> = async () => {
     {
       title: "Praktisk",
       path: "/practical",
-      items: [{ title: "Arrangementsregler", path: "/event/rules" }],
+      items: [
+        { title: "Arrangementsregler", path: "/event/rules" },
+        { title: "Konstruksjonsregler", path: "/event/construction-rules" },
+      ],
     },
     {
       title: "Billetter",

--- a/src/types/info.ts
+++ b/src/types/info.ts
@@ -9,6 +9,7 @@ export interface FaqSnippet {
 export interface InfoPageSnippet {
   title: string;
   url: string;
+  show_in_menu?: boolean;
 }
 
 export interface InfoPage extends MinimalApiPage {

--- a/src/types/info.ts
+++ b/src/types/info.ts
@@ -9,7 +9,7 @@ export interface FaqSnippet {
 export interface InfoPageSnippet {
   title: string;
   url: string;
-  show_in_menu?: boolean;
+  show_in_menus?: boolean;
 }
 
 export interface InfoPage extends MinimalApiPage {


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/176
Blocked by: https://github.com/gathering/tgno-backend/pull/47

Before we roll this out we should probably make sure info is in the loop and that the relevant pages are ready (marked as show in menu, and in the correct order)