### PR TITLE
feat: annotate review app namespaces to allow cleanup

### DIFF
--- a/tools/create-preview.py
+++ b/tools/create-preview.py
@@ -54,6 +54,10 @@ application = {
       "targetRevision": args.repo_revision
     },
     "syncPolicy": {
+        "managedNamespaceMetadata": {
+            "labels": {},
+            "annotations": {},
+        },
         "syncOptions": [
             "CreateNamespace=true",
             "ServerSideApply=true",


### PR DESCRIPTION
Noticed a lot of review app namespaces being left in k8s after review app is deleted. Argo CD discussion thread seems to indicate that this change should allow Argo CD to track namespace after creation and include it in cleanup tasks.