### PR TITLE
feat(schedule): sticky filtering menu

### DIFF
--- a/src/components/floating-nav/FloatingNav.astro
+++ b/src/components/floating-nav/FloatingNav.astro
@@ -7,7 +7,6 @@ interface Props {
 }
 
 const { closeOnNavigate } = Astro.props;
-//class="fixed bg-black/90 right-6 bottom-6 left-6 p-6 pb-10 hidden max-h-[80vh] overflow-y-auto rounded-3xl rounded-br-[2rem]"
 ---
 
 <script>
@@ -97,7 +96,7 @@ const { closeOnNavigate } = Astro.props;
   <nav
     id="floating-nav-contents"
     data-part="floating-nav-contents"
-    class="fixed right-6 bottom-6 max-w-26 bg-black/90 p-6 pb-10 hidden max-h-[80vh] overflow-y-auto rounded-3xl rounded-br-[2rem]"
+    class="fixed right-6 bottom-6 ml-6 max-w-26 bg-black/90 p-6 pb-10 hidden max-h-[80vh] overflow-y-auto rounded-3xl rounded-br-[2rem]"
   >
     <slot name="content" />
   </nav>

--- a/src/components/icons/ChevronDownSymbol.astro
+++ b/src/components/icons/ChevronDownSymbol.astro
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="icon icon-tabler icons-tabler-outline icon-tabler-chevron-down"
+  ><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path
+    d="M6 9l6 6l6 -6"></path></svg
+>

--- a/src/components/icons/FilterSymbol.astro
+++ b/src/components/icons/FilterSymbol.astro
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="icon icon-tabler icons-tabler-outline icon-tabler-filter"
+  ><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path
+    d="M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227z"
+  ></path></svg
+>

--- a/src/components/schedule/ActiveFilterNav.astro
+++ b/src/components/schedule/ActiveFilterNav.astro
@@ -1,0 +1,50 @@
+---
+import CloseSymbol from "../icons/CloseSymbol.astro";
+import FilterCloseSymbol from "../icons/FilterCloseSymbol.astro";
+
+export interface ActiveFilter {
+  name: string;
+  slug: string;
+  url: string;
+  required?: boolean;
+}
+
+interface Props {
+  activeFilters: Array<{
+    name: string;
+    slug: string;
+    url: string;
+    required?: boolean;
+  }>;
+  resetUrl?: string;
+}
+
+const { activeFilters, resetUrl } = Astro.props;
+const optionalFilters = activeFilters.filter(
+  ({ required }) => !required,
+).length;
+---
+
+{
+  activeFilters.length ? (
+    <div class="flex flex-row flex-wrap gap-2 mt-4">
+      {activeFilters.map(({ name, required, url }) => (
+        <a
+          href={url}
+          class="flex flex-row items-center gap-2 py-1 px-2 border rounded-md text-md font-bold bg-orange-500 text-black border-orange-500 hover:bg-white hover:text-backgroundSecondary"
+        >
+          {name}
+          {!required ? <CloseSymbol /> : null}
+        </a>
+      ))}
+      {resetUrl && optionalFilters ? (
+        <a
+          href={resetUrl}
+          class="flex flex-row items-center gap-2 py-1 px-2 border rounded-md text-md font-bold bg-orange-500 text-black border-orange-500 hover:bg-white hover:text-backgroundSecondary"
+        >
+          <FilterCloseSymbol />
+        </a>
+      ) : null}
+    </div>
+  ) : null
+}

--- a/src/components/schedule/Event.astro
+++ b/src/components/schedule/Event.astro
@@ -1,5 +1,5 @@
 ---
-import type { Event } from "../../types";
+import type { Event, Tag } from "../../types";
 import CalendardSymbol from "../icons/CalendardSymbol.astro";
 import ClockSymbol from "../icons/ClockSymbol.astro";
 import CloseSymbol from "../icons/CloseSymbol.astro";
@@ -7,7 +7,13 @@ import ArrowSymbol from "../icons/ArrowSymbol.astro";
 import ExternalLinkSymbol from "../icons/ExternalLinkSymbol.astro";
 
 type Props = Event & {
-  highlightedTags?: string[];
+  expanded?: boolean;
+  location?: {
+    name: string;
+    slug: string;
+    url?: string;
+    active?: boolean;
+  };
 };
 
 const AVAILABLE_STYLES = {
@@ -44,21 +50,23 @@ const {
   title,
   description,
   start,
-  tags = [],
   related_url,
   cancelled,
   facts,
   strings,
-  highlightedTags = [],
+  expanded = false,
+  location,
 } = Astro.props;
 let style = AVAILABLE_STYLES.default;
 
-if (facts.ended) {
-  style = AVAILABLE_STYLES.ended;
-} else if (cancelled) {
-  style = AVAILABLE_STYLES.cancelled;
-} else if (["start", "both"].includes(facts.extendingQuery)) {
-  style = AVAILABLE_STYLES.minimal;
+if (!expanded) {
+  if (facts.ended) {
+    style = AVAILABLE_STYLES.ended;
+  } else if (cancelled) {
+    style = AVAILABLE_STYLES.cancelled;
+  } else if (["start", "both"].includes(facts.extendingQuery)) {
+    style = AVAILABLE_STYLES.minimal;
+  }
 }
 
 let duration = strings.duration;
@@ -77,6 +85,11 @@ switch (facts.extendingQuery) {
     duration = `${strings.startDate} ${strings.startTime} - ${strings.endDate} ${strings.endTime}`;
     DurationSymbol = CalendardSymbol;
     break;
+}
+
+if (expanded) {
+  duration = `${strings.startDate} ${strings.startTime} - ${strings.endDate} ${strings.endTime}`;
+  DurationSymbol = CalendardSymbol;
 }
 ---
 
@@ -129,44 +142,35 @@ switch (facts.extendingQuery) {
   });
 </script>
 
-<article data-component="event" class={`group collapsed ${style.class}`}>
+<article
+  data-component="event"
+  class={`group ${expanded ? "" : "collapsed"} ${style.class}`}
+>
   <div class={`flex flex-col p-4 border ${style.styles} rounded-xl block mb-4`}>
     {
-      style.tags || related_url ? (
+      location || related_url ? (
         <div class="flex flex-row mb-1">
           <div class="text-md font-bold flex flex-row flex-wrap">
-            {tags
-              .filter((tag) => !tag.hidden)
-              .map((tag) => {
-                const active = highlightedTags.includes(tag.slug);
-                return active
-                  ? {
-                      ...tag,
-                      active: true,
-                      secondary: false,
-                    }
-                  : tag;
-              })
-              .map(({ slug, name, active = false, secondary }) => (
-                <a
-                  href={`/schedule?tags=${slug}`}
-                  data-part="tag-trigger"
-                  data-tag={slug}
-                  class={`border rounded-md flex flex-row mr-2 mb-2 py-1 px-2 hover:bg-white hover:text-backgroundSecondary ${active ? "bg-orange-500 text-black border-orange-500" : "border-white"} ${secondary ? "group-[.collapsed]:hidden" : ""}`}
-                >
-                  {name}
-                  {active ? <CloseSymbol /> : null}
-                </a>
-              ))}
+            {location ? (
+              <a
+                href={location.url}
+                class={`border rounded-md flex flex-row mr-2 mb-2 py-1 px-2 ${location.url ? "hover:bg-white hover:text-backgroundSecondary" : ""} ${location.active ? "bg-orange-500 text-black border-orange-500" : "border-white"}`}
+              >
+                {location.name}
+                {location.active && location.url ? <CloseSymbol /> : null}
+              </a>
+            ) : null}
           </div>
           {related_url ? (
             <a
               href={related_url}
+              target="_blank"
               class="rounded-md h-fit p-2 ml-auto hover:bg-white hover:text-backgroundSecondary"
             >
               <ExternalLinkSymbol />
             </a>
           ) : null}
+          <slot />
         </div>
       ) : null
     }

--- a/src/components/schedule/FullFilterNav.astro
+++ b/src/components/schedule/FullFilterNav.astro
@@ -1,0 +1,58 @@
+---
+import type { Navigation } from "../../utils";
+import CloseSymbol from "../icons/CloseSymbol.astro";
+
+interface Props {
+  navigation: Navigation;
+}
+
+const TAG_STYLES =
+  "flex flex-row items-center gap-2 py-1 px-2 border rounded-md text-md";
+
+const { navigation } = Astro.props;
+---
+
+<div class="flex flex-col gap-4 max-w-2xl text-white">
+  <h3>Dag</h3>
+  <div class="flex flex-row flex-wrap gap-2">
+    {
+      navigation.dates.map((date, index) => (
+        <a
+          href={date.url}
+          class={`${TAG_STYLES} ${date.active ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
+        >
+          {date.name}
+          {date.active && index > 0 ? <CloseSymbol /> : null}
+        </a>
+      ))
+    }
+  </div>
+  <h3>Sted</h3>
+  <div class="flex flex-row flex-wrap gap-2">
+    {
+      navigation.locations.map((location) => (
+        <a
+          href={location.url}
+          class={`${TAG_STYLES} ${location.active ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
+        >
+          {location.name}
+          {location.active ? <CloseSymbol /> : null}
+        </a>
+      ))
+    }
+  </div>
+  <h3>Kategori</h3>
+  <div class="flex flex-row flex-wrap gap-2">
+    {
+      navigation.categories.map((category) => (
+        <a
+          href={category.url}
+          class={`${TAG_STYLES} ${category.active ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
+        >
+          {category.name}
+          {category.active ? <CloseSymbol /> : null}
+        </a>
+      ))
+    }
+  </div>
+</div>

--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -2,161 +2,224 @@
 import H2 from "../../components/H2.astro";
 import Main from "../../components/Main.astro";
 import Layout from "../../layouts/Layout.astro";
-import { fetchEvents } from "../../utils";
+import { Calendar, isTag, isDateOption, tagsOfTypes } from "../../utils";
 import Event from "../../components/schedule/Event.astro";
 import DayHeader from "../../components/schedule/DayHeader.astro";
 import CloseSymbol from "../../components/icons/CloseSymbol.astro";
 import ContentContainer from "../../components/ContentContainer.astro";
+import FloatingNav from "../../components/floating-nav/FloatingNav.astro";
+import type { DateOption, TagWithMeta, Filter } from "../../utils";
+import type { Tag } from "../../types";
+import ChevronDownSymbol from "../../components/icons/ChevronDownSymbol.astro";
+import ActiveFilterNav, {
+  type ActiveFilter,
+} from "../../components/schedule/ActiveFilterNav.astro";
+import FullFilterNav from "../../components/schedule/FullFilterNav.astro";
 
-// In the future we could probably fetch this from the API if we really wanted to
-const CONFIG = {
-  mainFilters: [
-    {
-      slug: "all",
-      label: "Alle",
-      start: "2025-04-16",
-      end: "2025-04-21",
-    },
-    ...[16, 17, 18, 19, 20].map((date) => {
-      // TODO: Adjust timezone to +1 when filtering for dates outside of summer time
-      const start = `2025-04-${date} 00:00+02:00`;
-      const end = `2025-04-${date + 1} 02:00+02:00`;
-      return {
-        slug: `2025-04-${date}`,
-        label: new Date(start).toLocaleDateString("no-NO", {
-          weekday: "long",
-          day: "numeric",
-        }),
-        start,
-        end,
-      };
-    }),
-  ],
-  categoryFilters: [],
-  locationFilters: [],
+type Nullablefilter = Omit<Filter, "date"> & {
+  date?: Filter["date"];
 };
 
-const today = new Date();
-const requestedDate = Astro.url.searchParams.get("date");
-const todaySlug = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
-const dateFilter =
-  // Try to use date-slug from url if present
-  CONFIG.mainFilters.find((f) => f.slug === requestedDate) ||
-  // otherwise try to use today's date
-  CONFIG.mainFilters.find((f) => f.slug === todaySlug) ||
-  // and if that fails use the first filter
-  CONFIG.mainFilters[0];
+function getUrl({ date, locations, categories }: Nullablefilter) {
+  const url = new URL(Astro.url);
+  url.search = "";
 
-const tagsFilter = (Astro.url.searchParams.get("tags") || "")
-  .split(",")
-  .filter(Boolean);
+  if (date) {
+    url.searchParams.set("date", date.slug);
+  }
+  if (locations.length) {
+    url.searchParams.set("locations", locations.join(","));
+  }
+  if (categories.length) {
+    url.searchParams.set("categories", categories.join(","));
+  }
+  return url;
+}
 
-const events = (
-  await fetchEvents({
-    ...dateFilter,
-    tags: tagsFilter,
-    api_url: import.meta.env.API_URL,
-  })
-).filter((event) => ["none", "end"].includes(event.facts.extendingQuery));
+const getAdjustedFilter = (
+  filterChange: {
+    date?: DateOption;
+    location?: string;
+    category?: string;
+  },
+  currentFilter: Filter,
+): Nullablefilter => {
+  const { date, location, category } = filterChange;
+  const newFilter = {
+    date: date
+      ? date.slug === currentFilter.date?.slug
+        ? undefined
+        : date
+      : currentFilter.date,
+    // For now we just disallow more than one tag per location and category
+    locations: location
+      ? location === currentFilter.locations[0]
+        ? []
+        : [location]
+      : currentFilter.locations,
+    // For now we just disallow more than one tag per location and category
+    categories: category
+      ? category === currentFilter.categories[0]
+        ? []
+        : [category]
+      : currentFilter.categories,
+  };
+  return newFilter;
+};
+
+function getCalendarUrl(
+  entity: DateOption | TagWithMeta,
+  currentFilter: Filter,
+) {
+  if (isTag(entity)) {
+    return getUrl(
+      getAdjustedFilter(
+        entity.type === "location"
+          ? { location: entity.slug }
+          : { category: entity.slug },
+        currentFilter,
+      ),
+    );
+  }
+  if (isDateOption(entity)) {
+    return getUrl(
+      getAdjustedFilter(
+        {
+          date: entity,
+        },
+        currentFilter,
+      ),
+    );
+  }
+  return getUrl(currentFilter);
+}
+
+const getAdjustedUrl = (filterChange: {
+  date?: DateOption;
+  location?: string;
+  category?: string;
+}) => getUrl(getAdjustedFilter(filterChange, filter));
+
+const calendar = new Calendar(
+  {
+    event: parseInt(Astro.url.searchParams.get("event") || "0", 10) || null,
+    date: Astro.url.searchParams.get("date"),
+    locations: (Astro.url.searchParams.get("locations") || "").split(",") || [],
+    categories:
+      (Astro.url.searchParams.get("categories") || "").split(",") || [],
+  },
+  getCalendarUrl,
+);
+
+const events = await calendar.getEvents();
+const focusedEvent = await calendar.getFocusedEvent();
+
+const getLocation = (tags: Tag[]) => {
+  const location = tags.filter(tagsOfTypes(["location"])).pop();
+  return location ? calendar.getDecoratedTag(location) : undefined;
+};
+
+const filter = calendar.getFilter();
+const navigation = calendar.getNavigation();
 ---
 
-<script>
-  function changeFilter({ tags, date }: { tags?: string; date?: string }) {
-    const currentUrl = new URL(window.location.href);
-    if (tags === currentUrl.searchParams.get("tags") || tags === "") {
-      currentUrl.searchParams.delete("tags");
-    } else if (tags) {
-      currentUrl.searchParams.set("tags", tags);
-    }
-    if (date === currentUrl.searchParams.get("date") || date === "") {
-      currentUrl.searchParams.delete("date");
-    } else if (date) {
-      currentUrl.searchParams.set("date", date);
-    }
-    window.location.href = `${currentUrl.pathname}${currentUrl.search}`;
-  }
-
-  document
-    .querySelectorAll("[data-component='schedule'] [data-part='tag-trigger']")
-    .forEach((trigger) => {
-      const tags = trigger.getAttribute("data-tag");
-      if (typeof tags !== "string") {
-        return;
+<Layout
+  title="The Gathering - Program"
+  description="Her finner du programmet for hva som skjer innenfor E-Sport, Kreativia, konserter og mer under The Gathering 2025."
+  type="website"
+  jsonLd={focusedEvent
+    ? {
+        "@context": "https://schema.org",
+        "@type": "Event",
+        name: focusedEvent.title,
+        startDate: focusedEvent.start,
+        endDate: focusedEvent.end,
+        description: focusedEvent.description,
+        eventStatus: focusedEvent.cancelled
+          ? "EventCancelled"
+          : "EventScheduled",
+        eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+        location: {
+          "@type": "Place",
+          name: "The Gathering",
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: "Hamar, Vikingskipet",
+            addressLocality: "Hamar",
+            postalCode: "2316",
+            addressCountry: "NO",
+          },
+        },
+        organizer: {
+          "@type": "Organization",
+          name: "The Gathering",
+          url: "https://www.gathering.org",
+        },
       }
-      trigger.addEventListener("click", (e) => {
-        e.preventDefault();
-        changeFilter({ tags });
-      });
-    });
-
-  document
-    .querySelectorAll("[data-component='schedule'] [data-part='date-trigger']")
-    .forEach((trigger) => {
-      const date = trigger.getAttribute("data-date");
-      if (typeof date !== "string") {
-        return;
-      }
-      trigger.addEventListener("click", (e) => {
-        e.preventDefault();
-        changeFilter({ date });
-      });
-    });
-</script>
-
-<Layout title="The Gathering - Program">
+    : undefined}
+>
   <Main>
     <ContentContainer variant="narrow">
       <section data-component="schedule">
         <H2 text="PROGRAM" />
-        <nav class="text-white font-bold mt-4 mb-8">
-          <div class="flex flex-row flex-wrap gap-2 max-w-2xl">
-            {
-              CONFIG.mainFilters.map(({ slug, label }) => (
-                <a
-                  href={`/schedule?date=${slug}`}
-                  data-part="date-trigger"
-                  data-date={slug}
-                  class={`border rounded-xl capitalize text-sm px-4 py-2 ${slug === dateFilter.slug ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
-                >
-                  {label}
-                </a>
-              ))
-            }
-          </div>
-        </nav>
         {
-          tagsFilter.length > 0 ? (
-            <a
-              href="/schedule"
-              class="flex items-center text-sm text-white mb-4 rounded-xl p-4 bg-white/5 hover:bg-white/10"
-              data-part="tag-trigger"
-              data-tag=""
+          focusedEvent ? (
+            <Event
+              {...focusedEvent}
+              location={getLocation(focusedEvent.tags)}
+              expanded
             >
-              <div class="w-90 flex flex-col md:flex-row md:items-center gap-2">
-                <p>
-                  Viser bare aktiviteter som skjer på {tagsFilter.join(", ")} i
-                  valgt periode.
-                </p>
-                <p class="font-bold">Klikk her for å vise alle.</p>
-              </div>
-              <aside class="min-w-10 ml-auto">
+              <a href="/schedule" class="">
                 <CloseSymbol />
-              </aside>
-            </a>
+              </a>
+            </Event>
           ) : null
         }
+        <nav class="text-white mt-4 mb-8">
+          <FloatingNav closeOnNavigate>
+            <button
+              slot="trigger"
+              class="flex flex-row gap-2 text-neutral-300 bg-white/10 py-2 px-3 rounded-lg"
+              >Filtrer <ChevronDownSymbol /></button
+            >
+            <span slot="content">
+              <FullFilterNav navigation={navigation} />
+            </span>
+          </FloatingNav>
+          <ActiveFilterNav
+            activeFilters={[
+              filter.date && {
+                ...filter.date,
+                url: getAdjustedUrl({ date: filter.date }).toString(),
+                required: filter.date.slug === "all",
+              },
+              ...filter.locations.map(calendar.getDecoratedTag),
+              ...filter.categories.map(calendar.getDecoratedTag),
+            ].filter(Boolean) as ActiveFilter[]}
+            resetUrl={getUrl({
+              locations: [],
+              categories: [],
+            }).toString()}
+          />
+        </nav>
       </section>
       <section data-component="schedule">
         {
-          events.map((event, i) =>
-            event.strings.startDate !== events[i - 1]?.strings.startDate ? (
-              <>
-                <DayHeader date={event.start} />
-                <Event {...event} highlightedTags={tagsFilter} />
-              </>
-            ) : (
-              <Event {...event} highlightedTags={tagsFilter} />
-            ),
+          events.length ? (
+            events.map((event, i) =>
+              event.strings.startDate !== events[i - 1]?.strings.startDate ? (
+                <>
+                  <DayHeader date={event.start} />
+                  <Event {...event} location={getLocation(event.tags)} />
+                </>
+              ) : (
+                <Event {...event} location={getLocation(event.tags)} />
+              ),
+            )
+          ) : (
+            <p class="text-white text-md">
+              No events found... Perhaps try removing one or more filters?
+            </p>
           )
         }
       </section>

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,4 +1,4 @@
-interface Tag {
+export interface Tag {
   id: number;
   name: string;
   slug: string;
@@ -18,11 +18,7 @@ export interface ApiEvent {
 }
 
 export interface Event extends ApiEvent {
-  tags: (Tag & {
-    active?: boolean;
-    secondary: boolean;
-    hidden: boolean;
-  })[];
+  tags: Tag[];
   facts: {
     immediate: Boolean;
     sameDay: Boolean;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,4 +1,4 @@
-import type { Event, FetchEventsResponse } from "../types";
+import type { Event, FetchEventsResponse, Tag } from "../types";
 import { typedFetch } from "./fetching";
 
 const TAG_TYPE_PRIO = {
@@ -7,21 +7,260 @@ const TAG_TYPE_PRIO = {
   misc: 2,
 };
 
+type DateOptionWithoutDate = {
+  name: string;
+  slug: string;
+  active?: boolean;
+  url?: string;
+  type: "date";
+};
+type DateOptionWithDate = DateOptionWithoutDate & {
+  start: string;
+  end: string;
+};
+export type DateOption = DateOptionWithDate | DateOptionWithoutDate;
+
+export type TagWithMeta = {
+  active?: boolean;
+  url?: string;
+} & Omit<Tag, "id" | "parent">;
+
+export interface EventQueryProperties {
+  date: DateOption;
+  tags: string[];
+}
+
+export const isDateOption = (entity: unknown): entity is DateOption =>
+  (entity as DateOption).type === "date" ||
+  !!(entity as DateOptionWithDate).start ||
+  !!(entity as DateOptionWithDate).end;
+
+export const isTag = (tag: unknown): tag is TagWithMeta =>
+  !isDateOption(tag) && !!(tag as TagWithMeta).type;
+
+export const tagsOfTypes =
+  (types: Array<"location" | "category" | "misc">) =>
+  (tag?: Partial<TagWithMeta>) =>
+    isTag(tag) && types.includes(tag.type || "misc");
+
+export const DEFAULT_DATE_OPTION = {
+  slug: "all",
+  name: "Alle dager",
+  type: "date" as const,
+};
+
+export interface Filter {
+  date: DateOption;
+  locations: string[];
+  categories: string[];
+}
+
+export interface Navigation {
+  dates: DateOption[];
+  locations: TagWithMeta[];
+  categories: TagWithMeta[];
+}
+
+type UrlCreator = (
+  entity: TagWithMeta | DateOption,
+  currentFilter: Filter,
+) => URL;
+
+export class Calendar {
+  query: {
+    event: number | null;
+    date: string | null;
+    locations: string[];
+    categories: string[];
+  } = {
+    event: null,
+    date: null,
+    locations: [],
+    categories: [],
+  };
+
+  _navigationConfig?: Navigation;
+  _navigation?: Navigation;
+  _filter?: Filter;
+  _events?: Event[];
+  _focusedEvent?: Event;
+
+  today: Date;
+  todaySlug: string;
+  createUrl?: UrlCreator;
+
+  constructor(query: typeof this.query, urlCreator?: UrlCreator) {
+    this.query = {
+      ...query,
+      locations: query.locations.filter(Boolean),
+      categories: query.categories.filter(Boolean),
+    };
+    this.today = new Date();
+    this.todaySlug = `${this.today.getFullYear()}-${String(this.today.getMonth() + 1).padStart(2, "0")}-${String(this.today.getDate()).padStart(2, "0")}`;
+    this.createUrl = urlCreator;
+  }
+
+  getEvents = async () => {
+    if (!this._events) {
+      const filter = this.getFilter();
+      this._events = (
+        await fetchEvents({
+          date: filter.date,
+          tags: [...filter.locations, ...filter.categories],
+          api_url: import.meta.env.API_URL,
+        })
+      ).filter((event) => ["none", "end"].includes(event.facts.extendingQuery));
+    }
+    return this._events;
+  };
+
+  getFocusedEvent = async () => {
+    if (!this._focusedEvent && this.query.event && this.query.event > 0) {
+      return (await this.getEvents()).find(({ id }) => id === this.query.event);
+    }
+    return this._focusedEvent;
+  };
+
+  getFilter = (): Filter => {
+    return (
+      this._filter ?? {
+        date:
+          // Try to use date-slug from url if present
+          this.getNavigationConfig().dates.find(
+            (f) => f.slug === this.query.date,
+          ) ||
+          // otherwise try to use today's date
+          this.getNavigationConfig().dates.find(
+            (f) => f.slug === this.todaySlug,
+          ) ||
+          // and if that fails use the first filter
+          this.getNavigationConfig().dates[0],
+        locations: this.query.locations
+          // Only allow filtering on locations explicitly listed in navigation
+          .filter((location) =>
+            this.getNavigationConfig().locations.some(
+              (l) => l.slug === location,
+            ),
+          ),
+        categories: this.query.categories,
+      }
+    );
+  };
+
+  isActiveTag = (slug: string) => {
+    const filter = this.getFilter();
+    return [...filter.categories, ...filter.locations].includes(slug);
+  };
+
+  // Shortcut to get tag from navigation, which is what determines allowed filters, active states, etc
+  getDecoratedTag = (slugOrTag: string | Tag): TagWithMeta | undefined => {
+    const slug = typeof slugOrTag === "string" ? slugOrTag : slugOrTag?.slug;
+    const navigationConfig = this.getNavigationConfig();
+    return [...navigationConfig.locations, ...navigationConfig.categories].find(
+      (navTag) => navTag.slug === slug,
+    );
+  };
+
+  getNavigation = () => {
+    if (!this._navigation) {
+      const filter = this.getFilter();
+      const tagWithMeta = (tag: TagWithMeta): TagWithMeta => {
+        return {
+          ...tag,
+          ...(this.createUrl
+            ? { url: this.createUrl(tag, this.getFilter()).toString() }
+            : {}),
+          // Only highlight if we actually filter on tag
+          active:
+            filter.locations.includes(tag.slug) ||
+            filter.categories.includes(tag.slug),
+        };
+      };
+      const navigation = this.getNavigationConfig();
+      // Add active states to navigation based on current url/filter
+      navigation.locations = navigation.locations.map(tagWithMeta);
+      navigation.categories = navigation.categories.map(tagWithMeta);
+      navigation.dates = navigation.dates.map((date) => ({
+        ...date,
+        ...(this.createUrl
+          ? { url: this.createUrl(date, this.getFilter()).toString() }
+          : {}),
+        active: filter.date?.slug === date.slug,
+      }));
+      this._navigation = navigation;
+    }
+
+    return this._navigation;
+  };
+
+  getNavigationConfig = () => {
+    // In the future we could probably fetch this from the API if we really wanted to
+    return (this._navigationConfig ??= {
+      dates: [
+        DEFAULT_DATE_OPTION,
+        ...[16, 17, 18, 19, 20].map((date) => {
+          // TODO: Adjust timezone to +1 when filtering for dates outside of summer time
+          const start = `2025-04-${date} 00:00+02:00`;
+          const end = `2025-04-${date + 1} 02:00+02:00`;
+          return {
+            slug: `2025-04-${date}`,
+            name: new Date(start).toLocaleDateString("no-NO", {
+              weekday: "long",
+              day: "numeric",
+            }),
+            start,
+            end,
+            type: "date" as const,
+          };
+        }),
+      ],
+      categories: [
+        {
+          slug: "esport",
+          name: "Esport",
+          type: "category",
+        },
+        {
+          slug: "kreativia",
+          name: "Kreativia",
+          type: "category",
+        },
+      ],
+      locations: [
+        {
+          slug: "hovedscenen",
+          name: "Hovedscenen",
+          type: "location",
+        },
+        {
+          slug: "kreativiascenen",
+          name: "Kreativscenen",
+          type: "location",
+        },
+        {
+          slug: "esportscenen",
+          name: "Esportscenen",
+          type: "location",
+        },
+      ],
+    });
+  };
+}
+
 export const fetchEvents = async ({
-  start: reqStart,
-  end: reqEnd,
+  date,
   tags,
   api_url,
-}: {
-  start?: string;
-  end?: string;
-  tags?: string[];
+}: EventQueryProperties & {
   api_url: string;
 }): Promise<Event[]> => {
+  const hasDates = (date: DateOption): date is DateOptionWithDate =>
+    !!(date as DateOptionWithDate).start && !!(date as DateOptionWithDate).end;
+
   const url = new URL(`${api_url}api/v2/program/events`);
-  if (reqStart && reqEnd) {
-    url.searchParams.set("start", reqStart);
-    url.searchParams.set("end", reqEnd);
+  if (hasDates(date)) {
+    url.searchParams.set("start", date.start);
+    url.searchParams.set("end", date.end);
   }
   if (tags?.length) {
     url.searchParams.set("tags", tags.join(","));
@@ -34,8 +273,8 @@ export const fetchEvents = async ({
   return data.map((event) => {
     const startObj = new Date(event.start);
     const endObj = new Date(event.end);
-    const reqStartObj = reqStart ? new Date(reqStart) : null;
-    const reqEndObj = reqEnd ? new Date(reqEnd) : null;
+    const reqStartObj = hasDates(date) ? new Date(date.start) : null;
+    const reqEndObj = hasDates(date) ? new Date(date.end) : null;
 
     const newEvent: Event = {
       ...event,
@@ -44,7 +283,6 @@ export const fetchEvents = async ({
         .sort((a, b) => TAG_TYPE_PRIO[a.type] - TAG_TYPE_PRIO[b.type])
         .map((tag) => ({
           ...tag,
-          secondary: tag.type !== "location",
           hidden: tag.slug === "meta",
         })),
       facts: {


### PR DESCRIPTION
First step of getting redesigned schedule in place. This first step is getting an explicit filtering menu in place, that is both available at top of page and sticky.

Also added experimental "highlighted event" functionality, not yet exposed on any actual buttons or links. The idea is that it will allow us to get SEO for individual events (the highlighted one), which is what google prefers over a list of events, but probably needs to be exposed in a smart way.

Ex. https://www.tg.no/schedule?event=3

Standard view
<img width="353" alt="Screenshot 2025-04-06 at 22 04 14" src="https://github.com/user-attachments/assets/aa6e392c-98dd-4ecb-aef7-3ecd6b3799ce" />

Top filtering menu
<img width="346" alt="Screenshot 2025-04-06 at 22 04 29" src="https://github.com/user-attachments/assets/dd919ee0-ad9d-4baa-ab22-146d730a9a6b" />

Floating filtering menu
<img width="355" alt="Screenshot 2025-04-06 at 22 06 36" src="https://github.com/user-attachments/assets/3c23f9ef-b8b7-48c3-a07c-f41d29f86778" />

Example of expanded view, note how only location is now shown
<img width="351" alt="Screenshot 2025-04-06 at 22 04 54" src="https://github.com/user-attachments/assets/f081d186-a0c7-45c5-842b-43cfee18fdc7" />

Highlighted event
<img width="350" alt="Screenshot 2025-04-06 at 22 11 36" src="https://github.com/user-attachments/assets/5d91ce6c-4458-4b81-9673-6ed8f69326e3" />