### PR TITLE
feat(schedule): apply main parts of calendar redesign

### DIFF
--- a/src/components/icons/LiveSymbol.astro
+++ b/src/components/icons/LiveSymbol.astro
@@ -1,0 +1,11 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  class="icon icon-tabler icons-tabler-filled icon-tabler-circle"
+  ><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path
+    d="M7 3.34a10 10 0 1 1 -4.995 8.984l-.005 -.324l.005 -.324a10 10 0 0 1 4.995 -8.336z"
+  ></path></svg
+>

--- a/src/components/schedule/ActiveFilterNav.astro
+++ b/src/components/schedule/ActiveFilterNav.astro
@@ -7,15 +7,11 @@ export interface ActiveFilter {
   slug: string;
   url: string;
   required?: boolean;
+  color?: string;
 }
 
 interface Props {
-  activeFilters: Array<{
-    name: string;
-    slug: string;
-    url: string;
-    required?: boolean;
-  }>;
+  activeFilters: ActiveFilter[];
   resetUrl?: string;
 }
 
@@ -28,10 +24,10 @@ const optionalFilters = activeFilters.filter(
 {
   activeFilters.length ? (
     <div class="flex flex-row flex-wrap gap-2 mt-4">
-      {activeFilters.map(({ name, required, url }) => (
+      {activeFilters.map(({ name, required, url, color }) => (
         <a
           href={url}
-          class="flex flex-row items-center gap-2 py-1 px-2 border rounded-md text-md font-bold bg-orange-500 text-black border-orange-500 hover:bg-white hover:text-backgroundSecondary"
+          class={`flex flex-row items-center gap-2 py-1 px-2 rounded-md text-md ${color ? "bg-" + color + "-500 text-black" : "border border-white text-white"} hover:bg-white hover:text-backgroundSecondary`}
         >
           {name}
           {!required ? <CloseSymbol /> : null}
@@ -40,7 +36,7 @@ const optionalFilters = activeFilters.filter(
       {resetUrl && optionalFilters ? (
         <a
           href={resetUrl}
-          class="flex flex-row items-center gap-2 py-1 px-2 border rounded-md text-md font-bold bg-orange-500 text-black border-orange-500 hover:bg-white hover:text-backgroundSecondary"
+          class="flex flex-row items-center gap-2 py-1 px-2 rounded-md text-md bg-orange-500 text-black hover:bg-white hover:text-backgroundSecondary"
         >
           <FilterCloseSymbol />
         </a>

--- a/src/components/schedule/DayHeader.astro
+++ b/src/components/schedule/DayHeader.astro
@@ -13,11 +13,7 @@ weekday = weekday.charAt(0).toUpperCase() + weekday.slice(1);
 ---
 
 <H3>
-  <time
-    datetime={date}
-    class="text-3xl flex flex-row gap-3 items-center mb-4 mt-8"
-  >
+  <time datetime={date} class="text-2xl mb-4 mt-8">
     {weekday}
-    <span class="flex border border-white rounded-2xl w-full h-4"></span>
   </time>
 </H3>

--- a/src/components/schedule/Event.astro
+++ b/src/components/schedule/Event.astro
@@ -1,10 +1,11 @@
 ---
-import type { Event, Tag } from "../../types";
+import type { Event } from "../../types";
 import CalendardSymbol from "../icons/CalendardSymbol.astro";
 import ClockSymbol from "../icons/ClockSymbol.astro";
 import CloseSymbol from "../icons/CloseSymbol.astro";
 import ArrowSymbol from "../icons/ArrowSymbol.astro";
 import ExternalLinkSymbol from "../icons/ExternalLinkSymbol.astro";
+import LiveSymbol from "../icons/LiveSymbol.astro";
 
 type Props = Event & {
   expanded?: boolean;
@@ -14,35 +15,6 @@ type Props = Event & {
     url?: string;
     active?: boolean;
   };
-};
-
-const AVAILABLE_STYLES = {
-  default: {
-    class: "default",
-    styles:
-      "text-black bg-white/95 border-blue-300/40 group-[.collapsed]:bg-white/5 group-[.collapsed]:text-white group-[.collapsed]:border-blue-300/40",
-    tags: true,
-  },
-  active: {
-    class: "default",
-    styles: "text-white bg-red-500/10 border-red-500/60",
-    tags: true,
-  },
-  ended: {
-    class: "ended",
-    styles: "text-white opacity-60 border-white/20",
-    tags: false,
-  },
-  cancelled: {
-    class: "cancelled",
-    styles: "text-white bg-red-500/10 border-red-500/60",
-    tags: false,
-  },
-  minimal: {
-    class: "minimal",
-    styles: "text-white opacity-60 border-white/20",
-    tags: false,
-  },
 };
 
 const {
@@ -57,15 +29,15 @@ const {
   expanded = false,
   location,
 } = Astro.props;
-let style = AVAILABLE_STYLES.default;
+let style = "default";
 
 if (!expanded) {
   if (facts.ended) {
-    style = AVAILABLE_STYLES.ended;
+    style = "ended";
   } else if (cancelled) {
-    style = AVAILABLE_STYLES.cancelled;
+    style = "cancelled";
   } else if (["start", "both"].includes(facts.extendingQuery)) {
-    style = AVAILABLE_STYLES.minimal;
+    style = "minimal";
   }
 }
 
@@ -92,6 +64,26 @@ if (expanded) {
   DurationSymbol = CalendardSymbol;
 }
 ---
+
+<style>
+  [data-component="event"] {
+    color: theme("colors.white");
+    border-color: theme("colors.white");
+    &.default {
+    }
+    &.live {
+      .live-symbol {
+        display: flex;
+      }
+    }
+    &.ended,
+    &.cancelled {
+      background-color: theme("colors.white" / 10%);
+    }
+    &.minimal {
+    }
+  }
+</style>
 
 <script>
   // TODO: Make generic toggle script/component?
@@ -144,75 +136,85 @@ if (expanded) {
 
 <article
   data-component="event"
-  class={`group ${expanded ? "" : "collapsed"} ${style.class}`}
+  class={`group ${expanded ? "" : "collapsed"} ${style}`}
 >
-  <div class={`flex flex-col p-4 border ${style.styles} rounded-xl block mb-4`}>
-    {
-      location || related_url ? (
-        <div class="flex flex-row mb-1">
-          <div class="text-md font-bold flex flex-row flex-wrap">
-            {location ? (
+  <div class={`flex flex-row block pb-4 pt-2 border-t border-white`}>
+    <aside class="w-24 mr-4">
+      {strings.startDateLong}
+    </aside>
+    <section class="ml-4 w-full">
+      {
+        location || related_url ? (
+          <div class="flex flex-row mb-1 mt-2">
+            <div class="text-md flex flex-row flex-wrap gap-2">
+              {location ? (
+                <a
+                  href={location.url}
+                  class={`rounded-md flex flex-row py-1 px-2 ${location.color ? "bg-" + location.color + "-500 text-black" : "text-white border-white"} ${location.url ? "hover:bg-white hover:text-backgroundSecondary" : ""} ${location.active ? "" : ""}`}
+                >
+                  {location.name}
+                  {location.active && location.url ? <CloseSymbol /> : null}
+                </a>
+              ) : null}
+            </div>
+            {related_url ? (
               <a
-                href={location.url}
-                class={`border rounded-md flex flex-row mr-2 mb-2 py-1 px-2 ${location.url ? "hover:bg-white hover:text-backgroundSecondary" : ""} ${location.active ? "bg-orange-500 text-black border-orange-500" : "border-white"}`}
+                href={related_url}
+                target="_blank"
+                class="rounded-md h-fit p-2 ml-auto hover:bg-white hover:text-backgroundSecondary"
               >
-                {location.name}
-                {location.active && location.url ? <CloseSymbol /> : null}
+                <ExternalLinkSymbol />
               </a>
             ) : null}
-          </div>
-          {related_url ? (
-            <a
-              href={related_url}
-              target="_blank"
-              class="rounded-md h-fit p-2 ml-auto hover:bg-white hover:text-backgroundSecondary"
-            >
-              <ExternalLinkSymbol />
-            </a>
-          ) : null}
-          <slot />
-        </div>
-      ) : null
-    }
-    <section
-      {...description
-        ? {
-            "data-part": "event-details-trigger",
-            "aria-controls": `event-${id}-details`,
-            "data-active": "false",
-            "aria-expanded": "false",
-          }
-        : {}}
-      class={`-mx-4 -mb-4 ${description ? "group-[.collapsed]:cursor-pointer group-[.collapsed]:hover:bg-white/10" : ""}`}
-    >
-      <h3 class="text-lg font-bold text-pretty mb-1 pt-1 px-4">
-        {title}
-      </h3>
-      {
-        description ? (
-          <div
-            class="mt-3 px-4 pt-2 pb-2 group-[.collapsed]:hidden w-full"
-            data-part="event-details"
-            id={`event-${id}-details`}
-            aria-role="details"
-          >
-            <p>{description}</p>
+            <slot />
           </div>
         ) : null
       }
-      <aside
-        class={`text-md flex flex-row gap-3 px-4 pt-2 pb-3 w-full rounded-b-xl group-[.collapsed]:bg-transparent group-[.collapsed]:text-white`}
+      <section
+        {...description
+          ? {
+              "data-part": "event-details-trigger",
+              "aria-controls": `event-${id}-details`,
+              "data-active": "false",
+              "aria-expanded": "false",
+            }
+          : {}}
+        class={`text-md ${description ? "group-[.collapsed]:cursor-pointer group-[.collapsed]:hover:bg-white/10" : ""}`}
       >
-        <time datetime={start} class="text-md flex flex-row gap-3">
-          <DurationSymbol />
-          {duration}
-        </time>
-        <span
-          class={`ml-auto hidden ${description ? "group-[.collapsed]:block" : ""}`}
+        <h3 class="font-semibold text-pretty mb-1 pt-1 flex flex-row">
+          <span class="flex w-3 -ml-5 mr-2 text-red-600 live-symbol hidden">
+            <LiveSymbol />
+          </span>
+          {title}
+        </h3>
+        {
+          description ? (
+            <div
+              class="mt-3 pb-2 group-[.collapsed]:hidden w-full"
+              data-part="event-details"
+              id={`event-${id}-details`}
+              aria-role="details"
+            >
+              <p>{description}</p>
+            </div>
+          ) : null
+        }
+        <aside
+          class={`flex flex-row gap-3 pb-3 w-full rounded-b-xl group-[.collapsed]:bg-transparent group-[.collapsed]:text-white`}
         >
-          <ArrowSymbol />
-        </span>
-      </aside>
+          <time datetime={start} class="flex flex-row gap-3">
+            <span class="flex w-4">
+              <DurationSymbol />
+            </span>
+            {duration}
+          </time>
+          <span
+            class={`ml-auto hidden ${description ? "group-[.collapsed]:block" : ""}`}
+          >
+            <ArrowSymbol />
+          </span>
+        </aside>
+      </section>
     </section>
   </div>
 </article>

--- a/src/components/schedule/Event.astro
+++ b/src/components/schedule/Event.astro
@@ -14,6 +14,7 @@ type Props = Event & {
     slug: string;
     url?: string;
     active?: boolean;
+    color?: string;
   };
 };
 

--- a/src/components/schedule/FullFilterNav.astro
+++ b/src/components/schedule/FullFilterNav.astro
@@ -7,19 +7,25 @@ interface Props {
 }
 
 const TAG_STYLES =
-  "flex flex-row items-center gap-2 py-1 px-2 border rounded-md text-md";
+  "flex flex-row items-center gap-2 py-1 px-2 rounded-md text-md";
 
 const { navigation } = Astro.props;
+const getColors = ({ active, color }: { active?: boolean; color?: string }) => {
+  if (!active) {
+    return "border border-white text-white";
+  }
+  return color ? `bg-${color}-500 text-black` : "bg-orange-500 text-black";
+};
 ---
 
-<div class="flex flex-col gap-4 max-w-2xl text-white">
+<div class="flex flex-col gap-4 max-w-2xl text-white mb-8">
   <h3>Dag</h3>
   <div class="flex flex-row flex-wrap gap-2">
     {
       navigation.dates.map((date, index) => (
         <a
           href={date.url}
-          class={`${TAG_STYLES} ${date.active ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
+          class={`${TAG_STYLES} ${getColors(date)} hover:bg-white hover:text-backgroundSecondary`}
         >
           {date.name}
           {date.active && index > 0 ? <CloseSymbol /> : null}
@@ -33,7 +39,7 @@ const { navigation } = Astro.props;
       navigation.locations.map((location) => (
         <a
           href={location.url}
-          class={`${TAG_STYLES} ${location.active ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
+          class={`${TAG_STYLES} ${getColors(location)} hover:bg-white hover:text-backgroundSecondary`}
         >
           {location.name}
           {location.active ? <CloseSymbol /> : null}
@@ -47,7 +53,7 @@ const { navigation } = Astro.props;
       navigation.categories.map((category) => (
         <a
           href={category.url}
-          class={`${TAG_STYLES} ${category.active ? "bg-orange-500 text-black border-orange-500" : "border-white"} hover:bg-white hover:text-backgroundSecondary`}
+          class={`${TAG_STYLES} ${getColors(category)} hover:bg-white hover:text-backgroundSecondary`}
         >
           {category.name}
           {category.active ? <CloseSymbol /> : null}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -29,6 +29,7 @@ export interface Event extends ApiEvent {
     startTime: string;
     endTime: string;
     startDate: string;
+    startDateLong: string;
     endDate: string;
     duration: string;
   };

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -23,6 +23,7 @@ type DateOptionWithoutDate = {
   slug: string;
   active?: boolean;
   url?: string;
+  color?: string;
   type: "date";
 };
 type DateOptionWithDate = DateOptionWithoutDate & {
@@ -34,6 +35,7 @@ export type DateOption = DateOptionWithDate | DateOptionWithoutDate;
 export type TagWithMeta = {
   active?: boolean;
   url?: string;
+  color?: string;
 } & Omit<Tag, "id" | "parent">;
 
 export interface EventQueryProperties {
@@ -230,21 +232,25 @@ export class Calendar {
           slug: "esport",
           name: "Esport",
           type: "category",
+          color: "orange",
         },
         {
           slug: "kreativia",
           name: "Kreativia",
           type: "category",
+          color: "blue",
         },
         {
           slug: "konsert",
           name: "Konsert",
           type: "category",
+          color: "purple",
         },
         {
           slug: "info",
           name: "Info",
           type: "meta",
+          color: "yellow",
         },
       ],
       locations: [
@@ -252,16 +258,19 @@ export class Calendar {
           slug: "hovedscenen",
           name: "Hovedscenen",
           type: "location",
+          color: "purple",
         },
         {
           slug: "kreativiascenen",
           name: "Kreativscenen",
           type: "location",
+          color: "blue",
         },
         {
           slug: "esportscenen",
           name: "Esportscenen",
           type: "location",
+          color: "orange",
         },
       ],
     });
@@ -325,6 +334,12 @@ export const fetchEvents = async ({
         startDate: startObj.toLocaleDateString("no-NO", {
           day: "numeric",
           weekday: "long",
+        }),
+        startDateLong: startObj.toLocaleDateString("no-NO", {
+          day: "numeric",
+          weekday: "long",
+          month: "long",
+          year: "numeric",
         }),
         endDate: endObj.toLocaleDateString("no-NO", {
           day: "numeric",


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/192

Will create a few follow up issues for minor details left out of first iteration. Main prio is to get changes out as soon as possible so that we unblock others from iterating on them during easter.

## What it looks like

Ended events, followed by a live, and and expanded one
<img width="352" alt="Screenshot 2025-04-07 at 19 25 00" src="https://github.com/user-attachments/assets/da6efc21-5fc4-4279-b7f9-fa4af69f37e2" />

Colors used on top filtering menu (depends on category/location selected)
<img width="348" alt="Screenshot 2025-04-07 at 19 25 24" src="https://github.com/user-attachments/assets/e541c03c-ddbc-46b5-99d7-eb83d3e7ade3" />

Example of colors in use on sticky menu
<img width="350" alt="Screenshot 2025-04-07 at 19 25 37" src="https://github.com/user-attachments/assets/095f0156-3a6d-4cf8-8eaf-5263e27b01e2" />
