### PR TITLE
feat(practical): frontpage teaser and related tweaks

### DIFF
--- a/src/components/frontpage/DefaultHero.astro
+++ b/src/components/frontpage/DefaultHero.astro
@@ -15,14 +15,13 @@ const { class: classNames } = Astro.props;
     class="rounded-3xl"
     title="The Gathering 2025 - TG:RE - Trailer"
     videoId="B8khsj7usxc"
-    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen=""
-    cookie
-    frameborder="0"
+    allow="autoplay"
     embedParams={{
       autoplay: 1,
-      showinfo: 0,
+      playslinline: 1,
       rel: 0,
+      // @ts-ignore
+      mute: 1,
     }}
     slot="overlay"
   />

--- a/src/components/frontpage/DefaultHero.astro
+++ b/src/components/frontpage/DefaultHero.astro
@@ -1,0 +1,45 @@
+---
+import { YouTube } from "astro-lazy-youtube-embed";
+import Hero from "./Hero.astro";
+import Button from "../Button.astro";
+
+interface Props {
+  class?: string;
+}
+
+const { class: classNames } = Astro.props;
+---
+
+<Hero image="/images/tg19-lights.jpg" class={classNames}>
+  <YouTube
+    class="rounded-3xl"
+    title="The Gathering 2025 - TG:RE - Trailer"
+    videoId="B8khsj7usxc"
+    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen=""
+    cookie
+    frameborder="0"
+    embedParams={{
+      autoplay: 1,
+      showinfo: 0,
+      rel: 0,
+    }}
+    slot="overlay"
+  />
+  <div class="flex flex-col text-left">
+    <div class="w-full">
+      <h2 class="text-lg font-normal">Billettsalget er i gang!</h2>
+      <p class="text-4xl font-bold">16.-20. APRIL</p>
+    </div>
+    <aside class="mt-6 space-x-2">
+      <Button href="https://www.geekevents.org/tg25/#/shop" theme="orange"
+        >Kjøp billett</Button
+      >
+      <Button href="/tickets" theme="secondary">Mer info</Button>
+    </aside>
+  </div>
+  <Fragment slot="cta">
+    <p class="text-white">Lyst til å stille ut?</p>
+    <Button href="/about/expo" theme="secondary">Les hvordan</Button>
+  </Fragment>
+</Hero>

--- a/src/components/frontpage/Hero.astro
+++ b/src/components/frontpage/Hero.astro
@@ -1,56 +1,37 @@
 ---
-import { YouTube } from "astro-lazy-youtube-embed";
-import Button from "../Button.astro";
+interface Props {
+  image: string;
+  class?: string;
+}
+
+const { class: classNames, image } = Astro.props;
+const hideMobileImage = Astro.slots.has("overlay");
 ---
 
 <section
-  class="relative rounded-3xl sm:grid sm:grid-cols-5 gap-4 sm:p-4 space-y-4 sm:space-y-0"
+  class={`relative rounded-3xl sm:grid sm:grid-cols-5 gap-4 sm:p-4 space-y-4 sm:space-y-0 ${classNames}`}
 >
+  <img
+    src={image}
+    alt="Hero Image"
+    class={`${hideMobileImage ? "hidden" : ""} sm:block sm:absolute left-0 top-0 w-full h-full object-cover rounded-3xl z-0`}
+  />
   <div class="z-10 relative rounded-3xl flex flex-col col-span-3">
-    <YouTube
-      class="rounded-3xl"
-      title="The Gathering 2025 - TG:RE - Trailer"
-      videoId="B8khsj7usxc"
-      allow="autoplay"
-      embedParams={{
-        autoplay: 1,
-        playslinline: 1,
-        rel: 0,
-        // @ts-ignore
-        mute: 1,
-      }}
-    />
+    <slot name="overlay" />
   </div>
 
   <div class="z-10 relative flex flex-col justify-end col-span-2 space-y-4">
     <div
       class="w-full bg-blue-600 text-white p-4 rounded-3xl flex flex-col space-y-2 sm:rounded-2xl"
     >
-      <div class="flex flex-col text-left">
-        <div class="w-full">
-          <h2 class="text-lg font-normal">Billettsalget er i gang!</h2>
-          <p class="text-4xl font-bold">16.-20. APRIL</p>
-        </div>
-        <aside class="mt-6 space-x-2">
-          <Button href="https://www.geekevents.org/tg25/#/shop" theme="orange"
-            >Kjøp billett</Button
-          >
-          <Button href="/tickets" theme="secondary">Mer info</Button>
-        </aside>
-      </div>
+      <slot />
     </div>
     <div
       class="w-full bg-orange-600 text-white p-4 rounded-3xl flex flex-col space-y-2 sm:rounded-2xl"
     >
       <div class="flex space-x-2 items-center justify-between">
-        <p class="text-white">Lyst til å stille ut?</p>
-        <Button href="/about/expo" theme="secondary">Les hvordan</Button>
+        <slot name="cta" />
       </div>
     </div>
   </div>
-  <img
-    src="/images/tg19-lights.jpg"
-    alt="Hero Image"
-    class="hidden sm:block sm:absolute left-0 top-0 w-full h-full object-cover rounded-3xl z-0"
-  />
 </section>

--- a/src/components/frontpage/PracticalPageHero.astro
+++ b/src/components/frontpage/PracticalPageHero.astro
@@ -1,0 +1,54 @@
+---
+import Hero from "./Hero.astro";
+import Button from "../Button.astro";
+import { fetchInfoPageByPath } from "../../utils";
+
+interface Props {
+  class?: string;
+}
+
+const { class: classNames } = Astro.props;
+const path = "/practical/frontpage-test";
+//const path = "/practical/brev-fra-sikkerhetsansvarlig";
+//const path = "/practical/packing-list";
+
+const page = await fetchInfoPageByPath({
+  path,
+  apiUrl: import.meta.env.API_URL,
+});
+
+const { intro, main_image, title, body, meta } = page || {};
+---
+
+{
+  page ? (
+    <Hero
+      image={main_image?.sizes.large.url || "/images/tg19-lights.jpg"}
+      class={`${classNames} min-h-[600px]`}
+    >
+      <div class="flex flex-col text-left">
+        <div class="w-full p-2">
+          <h2 class="text-4xl font-bold text-pretty mb-2">{title}</h2>
+          {intro ? (
+            <p class="text-lg font-normal text-pretty">{intro}</p>
+          ) : (
+            <p>{body}</p>
+          )}
+        </div>
+        <aside class="mt-6 space-x-2">
+          {meta?.url ? (
+            <Button href={meta.url} theme="orange">
+              Få full oversikt
+            </Button>
+          ) : null}
+        </aside>
+      </div>
+      <Fragment slot="cta">
+        <p class="text-white">Besøke oss i påsken?</p>
+        <Button href="https://www.geekevents.org/tg25/#/shop" theme="secondary">
+          Kjøp dagsbillett
+        </Button>
+      </Fragment>
+    </Hero>
+  ) : null
+}

--- a/src/components/practical/PracticalPage.astro
+++ b/src/components/practical/PracticalPage.astro
@@ -9,13 +9,28 @@ import BodyText from "../BodyText.astro";
 
 type Props = InfoPage;
 
-const { title, faq = [], intro, body } = Astro.props;
+const { title, faq = [], intro, body, main_image } = Astro.props;
 ---
 
-<ContentContainer variant="wide">
+<ContentContainer variant="narrow">
   <section class="mb-4">
     <H1 text={title} />
     {intro ? <Intro text={intro} /> : null}
+    {
+      main_image && (
+        <div class="flex md:max-h-[50vh] mb-8">
+          <img
+            src={main_image.sizes.large.url}
+            srcset={Object.values(main_image.sizes)
+              .sort((a, b) => a.width - b.width)
+              .map((size) => `${size.url} ${size.width}w`)
+              .join(", ")}
+            alt={main_image.alt}
+            class="w-full rounded-3xl md:object-cover object-center"
+          />
+        </div>
+      )
+    }
     <BodyText htmlBody={body} />
   </section>
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,10 +2,10 @@
 import Layout from "../layouts/Layout.astro";
 import Main from "../components/Main.astro";
 import NewsComp from "../components/frontpage/NewsComp.astro";
-import Hero from "../components/frontpage/Hero.astro";
 import InfoBox from "../components/frontpage/InfoBox.astro";
 import FactBox from "../components/frontpage/FactBox.astro";
 import Button from "../components/Button.astro";
+import DefaultHero from "../components/frontpage/DefaultHero.astro";
 
 const TG_THEMES = {
   "2000": "The Gathering 1900 - Follow the Flow",
@@ -57,7 +57,7 @@ const randomFact = TG_FACTS[Math.floor(Math.random() * TG_FACTS.length)];
             I NORGES FETESTE PÅSKEHYTTE!
           </h2>
         </div>
-        <Hero image="/images/tg19-lights.jpg" />
+        <DefaultHero class="mb-8" />
       </div>
       <div class="sm:col-start-2 sm:col-span-7">
         <h2 class="text-2xl sm:text-6xl font-bold text-white text-center">

--- a/src/pages/practical/[...path].astro
+++ b/src/pages/practical/[...path].astro
@@ -54,11 +54,10 @@ const jsonLd = !!page.faq?.length
   search_description=`${page.meta.search_description}`
   introText=`${page.intro}`
   lang=`${page.meta.locale || "no"}`
+  image=`${page.main_image?.sizes.large.url}`
   jsonLd={jsonLd}
 >
   <Main>
-    <ContentContainer variant="narrow">
-      <PracticalPage {...page} />
-    </ContentContainer>
+    <PracticalPage {...page} />
   </Main>
 </Layout>

--- a/src/types/info.ts
+++ b/src/types/info.ts
@@ -1,3 +1,4 @@
+import type { Image } from "./images";
 import type { MinimalApiPage, PaginatedResponse } from "./utils";
 
 export interface FaqSnippet {
@@ -21,6 +22,7 @@ export interface InfoPage extends MinimalApiPage {
   intro?: string;
   pages?: InfoPageSnippet[];
   faq?: FaqSnippet[];
+  main_image?: Image;
 }
 
 export interface FaqPage extends MinimalApiPage {


### PR DESCRIPTION
Part of: https://github.com/gathering/tgno-frontend/issues/207
Blocked by: https://github.com/gathering/tgno-backend/pull/51

Page with image (always slim)
<img width="891" alt="Screenshot 2025-04-11 at 22 42 58" src="https://github.com/user-attachments/assets/8fe40440-addd-4db4-9c21-0900c8411204" />

Front desktop
<img width="1399" alt="Screenshot 2025-04-11 at 22 43 19" src="https://github.com/user-attachments/assets/1906b611-c6ca-4d92-b450-018df146895c" />

Front mobile
<img width="439" alt="Screenshot 2025-04-11 at 22 51 19" src="https://github.com/user-attachments/assets/5bdad3e7-e4df-4790-adac-396b2df697e7" />
