### PR TITLE
feat(frontpage): create news page hero

### DIFF
--- a/src/components/frontpage/NewsPageHero.astro
+++ b/src/components/frontpage/NewsPageHero.astro
@@ -1,0 +1,66 @@
+---
+import Hero from "./Hero.astro";
+import Button from "../Button.astro";
+import {
+  fetchArticleById,
+  fetchArticleIdBySlug,
+  fetchInfoPageByPath,
+} from "../../utils";
+
+interface Props {
+  class?: string;
+}
+
+const { class: classNames } = Astro.props;
+
+const slug = "bli-med-i-crew-for-en-dag";
+let articlePage = null;
+const id = await fetchArticleIdBySlug({
+  slug,
+  api_url: import.meta.env.API_URL,
+});
+
+if (id) {
+  articlePage = await fetchArticleById({
+    id,
+    api_url: import.meta.env.API_URL,
+  }).catch((e) => {
+    console.error(e.message);
+  });
+}
+
+const { intro, main_image, title, body } = articlePage || {};
+const articleUrl = `/news/${articlePage?.meta.slug}`;
+---
+
+{
+  articlePage ? (
+    <Hero
+      image={main_image?.sizes.large.url || "/images/tg19-lights.jpg"}
+      imageHref={articleUrl}
+      class={`${classNames} min-h-[30vh] sm:min-h-[600px]`}
+    >
+      <div class="flex flex-col text-left">
+        <div class="w-full p-2">
+          <h2 class="text-4xl font-bold text-pretty mb-2">{title}</h2>
+          {intro ? (
+            <p class="text-lg font-normal text-pretty">{intro}</p>
+          ) : (
+            <p>{body}</p>
+          )}
+        </div>
+        <aside class="mt-6 space-x-2">
+          <Button href={articleUrl} theme="orange">
+            Få full oversikt
+          </Button>
+        </aside>
+      </div>
+      <Fragment slot="cta">
+        <p class="text-white">Besøke oss i påsken?</p>
+        <Button href="/tickets" theme="secondary">
+          Kjøp dagsbillett
+        </Button>
+      </Fragment>
+    </Hero>
+  ) : null
+}


### PR DESCRIPTION
Part of: https://github.com/gathering/tgno-frontend/issues/207

Does nothing right now, but first part of supporting output from https://github.com/gathering/tgno-backend/pull/52 to dynamically control header section (and potentially also more parts of frontpage)