### PR TITLE
feat(schedule): add support for cancelled events

### DIFF
--- a/src/components/icons/CancelSymbol.astro
+++ b/src/components/icons/CancelSymbol.astro
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="icon icon-tabler icons-tabler-outline icon-tabler-cancel"
+  ><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path
+    d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0"></path><path
+    d="M18.364 5.636l-12.728 12.728"></path></svg
+>

--- a/src/components/schedule/Event.astro
+++ b/src/components/schedule/Event.astro
@@ -2,6 +2,7 @@
 import type { Event } from "../../types";
 import CalendardSymbol from "../icons/CalendardSymbol.astro";
 import ClockSymbol from "../icons/ClockSymbol.astro";
+import CancelSymbol from "../icons/CancelSymbol.astro";
 import CloseSymbol from "../icons/CloseSymbol.astro";
 import ArrowSymbol from "../icons/ArrowSymbol.astro";
 import ExternalLinkSymbol from "../icons/ExternalLinkSymbol.astro";
@@ -37,14 +38,14 @@ let style = "";
 if (!expanded) {
   if (facts.ended) {
     style = "has-ended";
-  } else if (cancelled) {
-    style = "is-cancelled";
   } else if (["start", "both"].includes(facts.extendingQuery)) {
     style = "minimal";
   }
 }
 
 const hasNotice = tags.some((tag) => tag.slug === "notice");
+// Let's rely on tag signal for now, but looking for unused signal in case it shows up
+const isCancelled = cancelled || tags.some((tag) => tag.slug === "cancelled");
 
 let duration = strings.duration;
 let DurationSymbol = ClockSymbol;
@@ -68,6 +69,11 @@ if (expanded) {
   duration = `${strings.startDate} ${strings.startTime} - ${strings.endDate} ${strings.endTime}`;
   DurationSymbol = CalendardSymbol;
 }
+
+if (isCancelled) {
+  duration = "Avlyst";
+  DurationSymbol = CancelSymbol;
+}
 ---
 
 <style>
@@ -76,8 +82,7 @@ if (expanded) {
     border-color: theme("colors.white");
     &.minimal {
     }
-    &.has-ended,
-    &.is-cancelled {
+    &.has-ended {
       opacity: 0.5;
     }
     &.is-live {
@@ -89,6 +94,15 @@ if (expanded) {
       .live-symbol {
         display: flex;
         color: theme("colors.yellow.600");
+      }
+    }
+    &.is-cancelled {
+      .live-symbol {
+        display: flex;
+        color: theme("colors.yellow.600");
+      }
+      .date {
+        text-decoration: line-through;
       }
     }
   }
@@ -145,12 +159,12 @@ if (expanded) {
 
 <article
   data-component="event"
-  class={`group ${expanded ? "" : "collapsed"} ${style} ${hasNotice ? "has-notice" : ""}`}
+  class={`group ${expanded ? "" : "collapsed"} ${style} ${hasNotice ? "has-notice" : ""} ${isCancelled ? "is-cancelled" : ""}`}
   data-start={start}
   data-end={end}
 >
   <div class={`flex flex-row block pb-4 pt-2 border-t border-white`}>
-    <aside class="w-24 mr-4">
+    <aside class="w-24 mr-4 date">
       {strings.startDateLong}
     </aside>
     <section class="ml-4 w-full">

--- a/src/components/schedule/Schedule.astro
+++ b/src/components/schedule/Schedule.astro
@@ -33,7 +33,7 @@ export interface Schedule extends HTMLElement {
       now: number;
       start: number;
       end: number;
-    }): "is-live" | "has-ended" | "is-cancelled" | "has-notice" | "" {
+    }): "is-live" | "has-ended" | "" {
       if (start <= now && end > now) {
         return "is-live";
       }
@@ -89,7 +89,7 @@ export interface Schedule extends HTMLElement {
       let isLive = false;
 
       this.events.forEach((event) => {
-        event.element.classList.remove("is-live", "has-ended", "is-cancelled");
+        event.element.classList.remove("is-live", "has-ended");
 
         const status = this.getStatus({
           start: event.start,


### PR DESCRIPTION
Ref ongoing calendar cleanups, this allows us to signal cancelled events in a similar way to how we do notices

If in the future
<img width="739" alt="Screenshot 2025-04-17 at 16 27 59" src="https://github.com/user-attachments/assets/a7f3ed54-b9a6-4eec-a011-ec699a22055d" />

If in the past
<img width="707" alt="Screenshot 2025-04-17 at 16 28 29" src="https://github.com/user-attachments/assets/4d568d13-8bb7-4bf3-a481-2bf6b67398b6" />
