### PR TITLE
feat(news): support custom publish date

### DIFF
--- a/src/components/NewsComp.astro
+++ b/src/components/NewsComp.astro
@@ -27,7 +27,11 @@ const { articles } = Astro.props;
               datetime={meta.first_published_at}
               class="text-sm text-gray-500"
             >
-              {new Date(meta.first_published_at).toLocaleDateString("en-US", {
+              {new Date(
+                meta.custom_published_at
+                  ? meta.custom_published_at
+                  : meta.first_published_at,
+              ).toLocaleDateString("en-US", {
                 year: "numeric",
                 month: "long",
                 day: "numeric",

--- a/src/components/frontpage/NewsComp.astro
+++ b/src/components/frontpage/NewsComp.astro
@@ -51,14 +51,15 @@ const gridStyles = singleColumn
                 datetime={article.meta.first_published_at}
                 class="text-sm text-gray-500"
               >
-                {new Date(article.meta.first_published_at).toLocaleDateString(
-                  "nb-NO",
-                  {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  },
-                )}
+                {new Date(
+                  article.meta.custom_published_at
+                    ? article.meta.custom_published_at
+                    : article.meta.first_published_at,
+                ).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
               </time>
             </div>
             <TeaserImage image={article.main_image} />

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -30,6 +30,10 @@ const article = await fetchArticleById({
   api_url: import.meta.env.API_URL,
 });
 
+const datePublished = article.meta.custom_published_at
+  ? article.meta.custom_published_at
+  : article.meta.first_published_at;
+
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "NewsArticle",
@@ -37,7 +41,7 @@ const jsonLd = {
   image: article.main_image?.sizes.large.url
     ? [article.main_image?.sizes.large.url]
     : [],
-  datePublished: article.meta.first_published_at,
+  datePublished,
   author: article.contributors.map((contributor) => ({
     "@type": "Person",
     name: contributor.name,
@@ -91,14 +95,11 @@ const jsonLd = {
           >
             Publisert:{" "}
             {
-              new Date(article.meta.first_published_at).toLocaleDateString(
-                "nb-NO",
-                {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                },
-              )
+              new Date(datePublished).toLocaleDateString("nb-NO", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })
             }
           </time>
           {


### PR DESCRIPTION
Adds support for existing custom publish date field, showing it on article page itself, news overview and frontpage widget.