### PR TITLE
fix(news): reduce floating image visual issues

### DIFF
--- a/src/components/BodyText.astro
+++ b/src/components/BodyText.astro
@@ -12,11 +12,13 @@ const { class: className, htmlBody: body } = Astro.props;
     .richtext-image {
       &.left {
         float: left;
+        clear: both;
         max-width: 40%;
         margin: 0 1rem 0.5rem 0;
       }
       &.right {
         float: right;
+        clear: both;
         max-width: 40%;
         margin: 0 0 0.5rem 1rem;
       }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,7 +10,7 @@ import BrandTiktok from "./icons/BrandTiktok.astro";
 ---
 
 <footer
-  class="flex flex-col gap-6 items-center mx-auto sm:flex-col sm:items-start max-w-7xl px-5 py-5 w-full"
+  class="flex flex-col gap-6 items-center mx-auto sm:flex-col sm:items-start max-w-7xl px-5 py-5 w-full clear-both"
 >
   <div class="sm:flex gap-6 grid">
     <div>

--- a/src/components/sponsors/SponsorContainer.astro
+++ b/src/components/sponsors/SponsorContainer.astro
@@ -3,7 +3,7 @@ import SponsorLogo from "./SponsorLogo.astro";
 ---
 
 <sponsor
-  class="flex flex-row flex-wrap justify-items-center justify-center items-center gap-6 md:gap-x-8 p-6 my-4 max-w-7xl mx-auto bg-background-secondary rounded-3xl"
+  class="flex flex-row flex-wrap justify-items-center justify-center items-center gap-6 md:gap-x-8 p-6 my-4 max-w-7xl mx-auto bg-background-secondary rounded-3xl clear-both"
 >
   <SponsorLogo
     filename="nexthop.svg"

--- a/src/pages/news/[slug].astro
+++ b/src/pages/news/[slug].astro
@@ -86,7 +86,7 @@ const jsonLd = {
       <Intro text={article.intro} />
       <BodyText class="mb-6" htmlBody={article.body} />
       <aside
-        class="mb-6 p-5 space-y-5 text-sm text-white/60 bg-background-secondary rounded"
+        class="my-6 p-5 space-y-5 clear-both text-sm text-white/60 bg-background-secondary rounded"
       >
         <section class="space-y-1">
           <time


### PR DESCRIPTION
Fixes floating image issue reported via slack, see (simulated) example in screenshot. We also tweak things a bit in general to make subsequent floating images with "too little" text between them behave a bit better.

<img width="954" height="569" alt="Screenshot 2026-01-28 at 20 18 38" src="https://github.com/user-attachments/assets/0a58f013-6665-4c9c-89b0-e64249bed25d" />
