### PR TITLE
Fix: color change

### DIFF
--- a/src/pages/tickets/index.astro
+++ b/src/pages/tickets/index.astro
@@ -107,7 +107,7 @@ const jsonLd = {
         <section
           class={`${boxStyles.join(" ")} sm:col-start-1 sm:col-span-7 bg-sky-500`}
         >
-          <H3>Billettypene for TG 2026</H3>
+          <H3 color="text-black">Billettypene for TG 2026</H3>
           <p>
             Vi tilbyr ulike billettyper for å tilpasse ditt behov. Velg den som
             passer deg best:


### PR DESCRIPTION
Changes the ticket types text to be black, to fit the current style.

I noticed further down on the page, there being more white titles, but as far as I remember, black text was used to meet contrast requirements?