### PR TITLE
fix (countdown): consistent color usage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,7 +60,7 @@ const randomFact = TG_FACTS[Math.floor(Math.random() * TG_FACTS.length)];
         </div>
         <TicketsHero class="min-h-[300px] mb-4" />
         <div
-          class="w-full bg-sky-400 md:bg-background-secondary p-4 rounded-3xl flex justify-center flex content-center items-center gap-2 min-[540px]:gap-10 flex-col min-[540px]:flex-row"
+          class="w-full bg-background-secondary p-4 rounded-3xl flex justify-center flex content-center items-center gap-2 min-[540px]:gap-10 flex-col min-[540px]:flex-row"
         >
           <Countdown
             targetDate="2026-04-01T09:00:00+02:00"


### PR DESCRIPTION
Makes the bg for the countdown stay "bg-secondary" across all screens. May become blue with the new homepage layout.

Closes #305 