### PR TITLE
fix(schedule): remove localhost by using relative urls

### DIFF
--- a/src/pages/schedule/index.astro
+++ b/src/pages/schedule/index.astro
@@ -40,7 +40,10 @@ function getUrl({ date, locations, categories }: Nullablefilter) {
   if (categories.length) {
     url.searchParams.set("categories", categories.join(","));
   }
-  return url;
+
+  // We explicitly only return the pathname and search and ignore host and protocol
+  // This means we get a relative url, and don't have to worry about Astro.url being correct
+  return url.pathname + url.search;
 }
 
 const getAdjustedFilter = (

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -77,7 +77,7 @@ export interface Navigation {
 type UrlCreator = (
   entity: TagWithMeta | DateOption,
   currentFilter: Filter,
-) => URL;
+) => string;
 
 export class Calendar {
   query: {


### PR DESCRIPTION
Fixes: https://github.com/gathering/tgno-frontend/issues/311

Fixes issue by using relative urls instead of absolute ones (that include domain and protocol).

---

In theory full url with `Astro.url` should work [per docs](https://docs.astro.build/en/reference/api-reference/#url).

> url will be a localhost URL in dev mode. When building a site, prerendered routes will receive a URL based on the [site](https://docs.astro.build/en/reference/configuration-reference/#site) and [base](https://docs.astro.build/en/reference/configuration-reference/#base) options. If site is not configured, prerendered pages will receive a localhost URL during builds as well.

So my theory is that we either need to make sure relevant `x-forwarded-host` domains are [allowed in security settings](https://docs.astro.build/en/reference/configuration-reference/#securityalloweddomains), that something funky is going on with production vs development mode, or that we just need to make sure the correct site options are set.

Wanted fix out there so that we are open to dig more at our own time, expecting that proper fix could be slightly more complex as they happen partly on build time and partly on runtime, depending on what exactly needs to be tweaked.