### PR TITLE
fix(astro): try using allowed domains to set site based on proxy headers

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,4 +17,24 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
+  security: {
+    allowedDomains: [
+      {
+        hostname: "tg.no",
+        protocol: "https",
+      },
+      {
+        hostname: "www.tg.no",
+        protocol: "https",
+      },
+      {
+        hostname: "dev.tg.no",
+        protocol: "https",
+      },
+      {
+        hostname: "**.preview.tg.no",
+        protocol: "https",
+      },
+    ],
+  },
 });


### PR DESCRIPTION
Closes: https://github.com/gathering/tgno-frontend/issues/324

Let's see if this helps in any way, or we need to dig into env variables per runtime and/or build context.

Might be able to see how this behaves already in preview app. If not rolling out into production shouldn't make things any worse than before.