### PR TITLE
feat(compo): clickable links

### DIFF
--- a/src/components/competitions/creative/CompetitionBox.astro
+++ b/src/components/competitions/creative/CompetitionBox.astro
@@ -44,7 +44,13 @@ const prizeGroups = prizes.every(Array.isArray) ? prizes : [prizes];
   category={category}
   class={classNames}
 >
-  <H2 text={name} color="" class="mb-0" />
+  {
+    url && (
+      <a href={url}>
+        <H2 text={name} color="" class="mb-0" />
+      </a>
+    )
+  }
   {description && <p>{description}</p>}
   {
     hasPrices


### PR DESCRIPTION
Makes the kreativia compo headlines clickable (links to sub page for compo).

One could experiment with adding an underline or similar on hover, but I don´t believe its necessary.

Closes #351 