### PR TITLE
feat(contact): use email instead of contact form

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -95,15 +95,12 @@ const boxStyles = [
       </section>
 
       <div class:list={[...boxStyles, "bg-white", "text-black"]}>
-        <H3 class="mb-4" color="text-black">Ta kontakt</H3>
-        <div id="zammad-feedback-form">
-          Kontaktskjema, om det ikke dukker opp ta kontakt med Hovedkontakt
-          nevnt under
-        </div>
-      </div>
-      <div class:list={[...boxStyles, "bg-white", "text-black"]}>
-        <h3 class="text-black mb-2 text-xl font-normal">Ring oss på</h3>
+        <h3 class="text-black mb-2 text-xl font-normal">Kontakt oss på</h3>
         <p class="text-3xl font-bold mb-4">
+          E-post: <a href="mailto:post@tg.no" class="not-prose underline"
+            >post@tg.no</a
+          >
+          <br />
           Tlf: <a href="tel:004722696900" class="not-prose underline"
             >22 69 69 00</a
           >


### PR DESCRIPTION
As requested on slack

<img width="853" height="440" alt="Screenshot 2026-05-24 at 20 17 27" src="https://github.com/user-attachments/assets/ce54fe30-4384-4b0a-aad3-7672e91d5339" />
