### PR TITLE
fix(practical): remove unused index page in favour of path based page

### DIFF
--- a/src/pages/practical/index.astro
+++ b/src/pages/practical/index.astro
@@ -1,5 +1,0 @@
----
-import PracticalPage from "./[...path].astro";
----
-
-<PracticalPage params={{ path: "" }} />


### PR DESCRIPTION
Removes index page without any content that for the most part just redirects to backend path based page. This seems to also fix the issue where https://www.tg.no/practical is unstyled in latest Astro/Tailwind versions.